### PR TITLE
Add accessible names to icon-only buttons

### DIFF
--- a/dongle/components/layout/Navbar.tsx
+++ b/dongle/components/layout/Navbar.tsx
@@ -84,6 +84,9 @@ export default function Navbar() {
           {/* Mobile menu button */}
           <button
             onClick={() => setIsMenuOpen(!isMenuOpen)}
+            aria-label={isMenuOpen ? "Close menu" : "Open menu"}
+            aria-expanded={isMenuOpen}
+            aria-controls="mobile-menu"
             className="md:hidden p-2 rounded-md text-zinc-600 dark:text-zinc-400 hover:text-black dark:hover:text-white"
           >
             <svg
@@ -105,7 +108,7 @@ export default function Navbar() {
 
       {/* Mobile menu */}
       {isMenuOpen && (
-        <div className="md:hidden bg-white dark:bg-black border-t border-zinc-200 dark:border-zinc-800">
+        <div id="mobile-menu" className="md:hidden bg-white dark:bg-black border-t border-zinc-200 dark:border-zinc-800">
           <div className="px-4 py-4 space-y-2">
             {navLinks.map((link) => (
               <Link

--- a/dongle/components/reviews/ReviewForm.tsx
+++ b/dongle/components/reviews/ReviewForm.tsx
@@ -64,9 +64,10 @@ export default function ReviewForm({
           <h3 className="text-xl font-bold">{initialReview ? "Edit Review" : "Add Review"}</h3>
           <p className="text-sm text-zinc-500">{projectName}</p>
         </div>
-        <button 
-          type="button" 
+        <button
+          type="button"
           onClick={onCancel}
+          aria-label="Close form"
           className="text-zinc-400 hover:text-zinc-600 dark:hover:text-zinc-200"
         >
           <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -84,6 +85,8 @@ export default function ReviewForm({
                 key={star}
                 type="button"
                 onClick={() => setRating(star)}
+                aria-label={`Rate ${star} star${star > 1 ? "s" : ""}`}
+                aria-pressed={rating === star}
                 className={`w-10 h-10 rounded-full flex items-center justify-center transition-all ${
                   rating >= star 
                     ? "bg-yellow-500 text-white shadow-lg shadow-yellow-500/20" 

--- a/dongle/components/reviews/ReviewList.tsx
+++ b/dongle/components/reviews/ReviewList.tsx
@@ -61,16 +61,18 @@ export default function ReviewList({ reviews, currentUserAddress, onEdit, onDele
             
             {currentUserAddress === review.userAddress && (
               <div className="flex gap-2">
-                <button 
+                <button
                   onClick={() => onEdit(review)}
+                  aria-label="Edit review"
                   className="p-2 hover:bg-zinc-100 dark:hover:bg-zinc-800 rounded-lg transition-colors text-zinc-500 hover:text-black dark:hover:text-white"
                 >
                   <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                     <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15.232 5.232l3.536 3.536m-2.036-5.036a2.5 2.5 0 113.536 3.536L6.5 21.036H3v-3.572L16.732 3.732z" />
                   </svg>
                 </button>
-                <button 
+                <button
                   onClick={() => onDelete(review.id)}
+                  aria-label="Delete review"
                   className="p-2 hover:bg-red-50 dark:hover:bg-red-900/20 rounded-lg transition-colors text-zinc-500 hover:text-red-500"
                 >
                   <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">

--- a/dongle/components/verify/VerificationStatus.tsx
+++ b/dongle/components/verify/VerificationStatus.tsx
@@ -93,7 +93,7 @@ export default function VerificationStatus({ initialProjectId }: VerificationSta
             onChange={(e) => setSearchInput(e.target.value)}
             className="flex-1"
           />
-          <Button type="submit" variant="secondary" className="mt-1" isLoading={isLoading}>
+          <Button type="submit" variant="secondary" className="mt-1" isLoading={isLoading} aria-label="Search verification status">
             <Search className="w-4 h-4" />
           </Button>
         </form>


### PR DESCRIPTION

Several icon-only buttons rendered with no text content and no
aria-label, so screen readers only announced them as generic
"button" controls.

Changes:
- ReviewList: edit and delete buttons now have aria-label
  ("Edit review", "Delete review")
- ReviewForm: close button has aria-label ("Close form"); star
  rating buttons have aria-label ("Rate N stars") and aria-pressed
  reflecting the selected rating
- Navbar: mobile menu toggle now has aria-label that reflects its
  current action ("Open menu" / "Close menu"), aria-expanded bound
  to the open/closed state, and aria-controls pointing to the menu
  panel's id
- VerificationStatus: search submit button has aria-label
  ("Search verification status")

No visual or behavioral changes; only accessibility attributes were
added.

Closes #67 
