### PR TITLE
fix(ui): keep button text visible during loading states and improve accessibility

### DIFF
--- a/dongle/components/ui/Button.tsx
+++ b/dongle/components/ui/Button.tsx
@@ -6,12 +6,13 @@ interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
   variant?: "primary" | "secondary" | "outline" | "ghost" | "error";
   size?: "sm" | "md" | "lg";
   isLoading?: boolean;
+  loadingText?: string;
   leftIcon?: React.ReactNode;
   rightIcon?: React.ReactNode;
 }
 
 export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
-  ({ className, variant = "primary", size = "md", isLoading, leftIcon, rightIcon, children, disabled, ...props }, ref) => {
+  ({ className, variant = "primary", size = "md", isLoading, loadingText, leftIcon, rightIcon, children, disabled, ...props }, ref) => {
     const variants = {
       primary: "bg-zinc-900 dark:bg-white text-white dark:text-zinc-900 hover:opacity-90",
       secondary: "bg-zinc-100 dark:bg-zinc-800 text-zinc-900 dark:text-white hover:bg-zinc-200 dark:hover:bg-zinc-700",
@@ -30,6 +31,7 @@ export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
       <button
         ref={ref}
         disabled={isLoading || disabled}
+        aria-busy={isLoading}
         className={cn(
           "inline-flex items-center justify-center gap-2 transition-all active:scale-[0.98] disabled:opacity-50 disabled:pointer-events-none font-medium",
           variants[variant],
@@ -39,12 +41,15 @@ export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
         {...props}
       >
         {isLoading ? (
-          <Loader2 className="w-4 h-4 animate-spin" />
+          <Loader2 className="w-4 h-4 animate-spin" aria-hidden="true" />
         ) : (
           leftIcon
         )}
-        {!isLoading && children}
+        {children}
         {!isLoading && rightIcon}
+        {isLoading && (loadingText || (!children && !props["aria-label"])) && (
+          <span className="sr-only">{loadingText || "Loading..."}</span>
+        )}
       </button>
     );
   }


### PR DESCRIPTION
## PR Description
**Problem**
The shared `Button` component was hiding its `children` while `isLoading` was true, only showing a spinner. This caused important context to be lost in several flows (e.g., whether a project was being submitted, updated, or loaded).

**Solution**
This PR updates the `Button` component to retain its meaningful text during loading states by default, while still ensuring forms prevent duplicate submits. 

**Key Changes:**
- **Preserved Context:** The button's label (`children`) is no longer hidden when `isLoading` is true. The spinner now gracefully replaces only the `leftIcon`.
- **Improved Accessibility:** 
  - Added `aria-busy={isLoading}` to communicate the loading state to screen readers.
  - Added `aria-hidden="true"` to the `Loader2` spinner to prevent repetitive or confusing screen reader announcements.
  - Introduced an optional `loadingText` prop. If a button lacks explicit text or an `aria-label`, a screen-reader-only (`sr-only`) fallback text is automatically rendered to ensure strict accessibility compliance.
- **Backwards Compatible:** Existing callers will continue to work without layout shifts. Duplicate submissions remain prevented as the `disabled={isLoading || disabled}` behavior was explicitly retained.

Closes #65
