### PR TITLE
[87] Fix local test runner dependency setup so npm test starts cleanly

### DIFF
--- a/dongle/package-lock.json
+++ b/dongle/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@hookform/resolvers": "^5.2.2",
+        "@rolldown/binding-darwin-arm64": "1.0.0-rc.17",
         "@stellar/freighter-api": "^6.0.1",
         "clsx": "^2.1.1",
         "lucide-react": "^1.11.0",
@@ -37,7 +38,16 @@
         "typescript": "5.9.3",
         "vitest": "^4.1.5"
       },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=9.0.0"
+      },
       "optionalDependencies": {
+        "@rolldown/binding-darwin-arm64": "^1.0.0-rc.17",
+        "@rolldown/binding-darwin-x64": "1.0.0-rc.17",
+        "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.17",
+        "@rolldown/binding-linux-x64-musl": "1.0.0-rc.17",
+        "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.17",
         "lightningcss-darwin-arm64": "^1.32.0"
       }
     },
@@ -1563,7 +1573,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1580,7 +1589,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1699,7 +1707,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1716,7 +1723,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1805,7 +1811,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [

--- a/dongle/package.json
+++ b/dongle/package.json
@@ -2,6 +2,10 @@
   "name": "dongle",
   "version": "0.1.0",
   "private": true,
+  "engines": {
+    "node": ">=18.0.0",
+    "npm": ">=9.0.0"
+  },
   "scripts": {
     "dev": "next dev",
     "build": "next build",
@@ -42,6 +46,11 @@
     "vitest": "^4.1.5"
   },
   "optionalDependencies": {
+    "@rolldown/binding-darwin-arm64": "^1.0.0-rc.17",
+    "@rolldown/binding-darwin-x64": "1.0.0-rc.17",
+    "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.17",
+    "@rolldown/binding-linux-x64-musl": "1.0.0-rc.17",
+    "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.17",
     "lightningcss-darwin-arm64": "^1.32.0"
   }
 }

--- a/dongle/services/stellar/soroban.service.ts
+++ b/dongle/services/stellar/soroban.service.ts
@@ -8,6 +8,11 @@ import {
 } from "stellar-sdk";
 import { SOROBAN_CONFIG, DONGLE_CONTRACTS } from "@/constants/contracts";
 import { walletService } from "@/services/wallet/wallet.service";
+import {
+  EXPECTED_NETWORK_LABEL,
+  EXPECTED_NETWORK_PASSPHRASE,
+  getNetworkLabel,
+} from "@/context/wallet.context";
 import { generateId } from "@/lib/id-generator";
 
 const server = new rpc.Server(SOROBAN_CONFIG.RPC_URL);


### PR DESCRIPTION
## Summary
- Add platform-specific `@rolldown/binding-*` optional dependencies so Vitest resolves native modules on macOS, Linux, and Windows.
- Declare Node 18+ and npm 9+ engine requirements in `package.json`.
- Refresh `package-lock.json` so dependency installation is reproducible across supported platforms.

## Test plan
- [x] `npm install` completes without missing Rolldown binding errors
- [x] `npm test` starts and executes the Vitest suite
- [x] `npm run build` succeeds

Closes #87