### PR TITLE
[117] Add empty and disconnected states for pages that depend on wallet data

### DIFF
--- a/dongle/__tests__/components/Navbar.test.tsx
+++ b/dongle/__tests__/components/Navbar.test.tsx
@@ -31,6 +31,7 @@ describe("Navbar active navigation", () => {
     vi.spyOn(walletContext, "useWallet").mockReturnValue({
       isConnected: false,
       isConnecting: false,
+      isFreighterAvailable: true,
       publicKey: null,
       walletNetwork: null,
       isCorrectNetwork: false,
@@ -68,6 +69,7 @@ describe("Navbar active navigation", () => {
     vi.spyOn(walletContext, "useWallet").mockReturnValue({
       isConnected: true,
       isConnecting: false,
+      isFreighterAvailable: true,
       publicKey: "GADMIN1234567890",
       walletNetwork: "Test SDF Network ; September 2015",
       isCorrectNetwork: true,

--- a/dongle/__tests__/components/WalletStatePanel.test.tsx
+++ b/dongle/__tests__/components/WalletStatePanel.test.tsx
@@ -1,0 +1,71 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import WalletStatePanel from "@/components/wallet/WalletStatePanel";
+import {
+  getFriendbotUrl,
+  getWalletStateContent,
+  isAccountNotFundedError,
+} from "@/components/wallet/wallet-states";
+
+describe("wallet-states", () => {
+  it("detects account-not-funded errors", () => {
+    expect(isAccountNotFundedError("Account not found on Stellar Testnet")).toBe(true);
+    expect(isAccountNotFundedError("Network timeout")).toBe(false);
+  });
+
+  it("builds Friendbot URL with encoded public key", () => {
+    expect(getFriendbotUrl("GTEST123")).toBe(
+      "https://friendbot.stellar.org?addr=GTEST123",
+    );
+  });
+
+  it("includes Freighter install guidance", () => {
+    const content = getWalletStateContent("freighter-missing");
+    expect(content.title).toBe("Install Freighter Wallet");
+    expect(content.primaryAction?.href).toContain("freighter.app");
+  });
+
+  it("includes Friendbot guidance for unfunded accounts", () => {
+    const content = getWalletStateContent("account-not-funded", {
+      publicKey: "GTEST123",
+    });
+    expect(content.title).toBe("Fund Your Testnet Account");
+    expect(content.primaryAction?.href).toContain("friendbot.stellar.org");
+  });
+});
+
+describe("WalletStatePanel", () => {
+  it("renders disconnected state with connect action", () => {
+    const onConnect = vi.fn();
+    render(
+      <WalletStatePanel
+        state="disconnected"
+        pagePurpose="Connect to continue."
+        onConnect={onConnect}
+      />,
+    );
+
+    expect(screen.getByText("Connect Your Wallet")).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: /Connect Wallet/i }));
+    expect(onConnect).toHaveBeenCalled();
+  });
+
+  it("renders wrong-network guidance", () => {
+    render(
+      <WalletStatePanel
+        state="wrong-network"
+        walletNetworkLabel="Mainnet"
+      />,
+    );
+
+    expect(screen.getByText("Wrong Network")).toBeInTheDocument();
+    expect(screen.getByText(/Mainnet/)).toBeInTheDocument();
+  });
+
+  it("renders Freighter install link", () => {
+    render(<WalletStatePanel state="freighter-missing" />);
+    const link = screen.getByRole("link", { name: /Get Freighter/i });
+    expect(link).toHaveAttribute("href", expect.stringContaining("freighter.app"));
+    expect(link).toHaveAttribute("target", "_blank");
+  });
+});

--- a/dongle/__tests__/pages/Admin.test.tsx
+++ b/dongle/__tests__/pages/Admin.test.tsx
@@ -30,6 +30,7 @@ function mockWallet(isConnected: boolean, publicKey: string | null) {
   vi.spyOn(walletContext, "useWallet").mockReturnValue({
     isConnected,
     isConnecting: false,
+    isFreighterAvailable: true,
     publicKey,
     walletNetwork: isConnected ? "Test SDF Network ; September 2015" : null,
     isCorrectNetwork: isConnected,
@@ -62,8 +63,9 @@ describe("Admin Dashboard - Authorization & High Risk Flows", () => {
 
       render(<AdminPage />);
 
+      expect(screen.getByText("Connect Your Wallet")).toBeInTheDocument();
       expect(
-        screen.getByText(/connect an authorized admin wallet/i),
+        screen.getByText(/authorized admin Freighter wallet/i),
       ).toBeInTheDocument();
     });
   });
@@ -177,7 +179,7 @@ describe("Admin Dashboard - Authorization & High Risk Flows", () => {
       mockWallet(false, null);
 
       render(<AdminPage />);
-      expect(screen.getByText("Access Restricted")).toBeInTheDocument();
+      expect(screen.getByText("Connect Your Wallet")).toBeInTheDocument();
     });
 
     it("verifies user is admin before showing actions", () => {

--- a/dongle/__tests__/pages/Submit.test.tsx
+++ b/dongle/__tests__/pages/Submit.test.tsx
@@ -3,6 +3,11 @@ import { render, screen, fireEvent } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import NewProjectPage from "@/app/projects/new/page";
 import * as walletContext from "@/context/wallet.context";
+import { useStellarAccount } from "@/hooks/useStellarAccount";
+
+vi.mock("@/hooks/useStellarAccount", () => ({
+  useStellarAccount: vi.fn(),
+}));
 
 vi.mock("next/link", () => ({
   default: ({
@@ -37,6 +42,16 @@ function mockWallet(overrides: Partial<ReturnType<typeof walletContext.useWallet
 }
 
 describe("Submit Project Page - High Risk Flows", () => {
+  beforeEach(() => {
+    vi.mocked(useStellarAccount).mockReturnValue({
+      account: null,
+      balances: null,
+      loading: false,
+      error: null,
+      refetch: vi.fn(),
+    });
+  });
+
   describe("Wallet Gating", () => {
     it("displays wallet connection message when not connected", () => {
       mockWallet();

--- a/dongle/__tests__/pages/Submit.test.tsx
+++ b/dongle/__tests__/pages/Submit.test.tsx
@@ -25,6 +25,7 @@ function mockWallet(overrides: Partial<ReturnType<typeof walletContext.useWallet
   vi.spyOn(walletContext, "useWallet").mockReturnValue({
     isConnected,
     isConnecting: false,
+    isFreighterAvailable: true,
     publicKey: null,
     walletNetwork: isConnected ? "Test SDF Network ; September 2015" : null,
     isCorrectNetwork: isConnected,

--- a/dongle/__tests__/pages/profile.test.tsx
+++ b/dongle/__tests__/pages/profile.test.tsx
@@ -31,6 +31,7 @@ function mockWallet(isConnected: boolean, publicKey: string | null, overrides: P
   vi.spyOn(walletContext, "useWallet").mockReturnValue({
     isConnected,
     isConnecting: false,
+    isFreighterAvailable: true,
     publicKey,
     walletNetwork: isConnected ? "Test SDF Network ; September 2015" : null,
     isCorrectNetwork: isConnected,
@@ -220,8 +221,8 @@ describe("Profile Page", () => {
 
       render(<ProfilePage />);
 
-      expect(screen.getByText("Account Not Found")).toBeInTheDocument();
-      expect(screen.getByText("Account not found on testnet")).toBeInTheDocument();
+      expect(screen.getByText("Fund Your Testnet Account")).toBeInTheDocument();
+      expect(screen.getByRole("link", { name: /Fund with Friendbot/i })).toBeInTheDocument();
     });
 
     it("should show disconnect button in error state", () => {

--- a/dongle/__tests__/services/review.service.test.ts
+++ b/dongle/__tests__/services/review.service.test.ts
@@ -543,7 +543,7 @@ describe("Review Service", () => {
     it("should remove unhelpful vote when voting helpful", () => {
       // Vote unhelpful
       reviewService.voteUnhelpful(reviewId, "user2");
-      let reviews = reviewService.getReviews();
+      const reviews = reviewService.getReviews();
       expect(reviews[0].unhelpfulVotes).toContain("user2");
 
       // Vote helpful

--- a/dongle/app/admin/page.tsx
+++ b/dongle/app/admin/page.tsx
@@ -1,9 +1,12 @@
 "use client";
 
 import { useState, useMemo } from "react";
-import { useWallet } from "@/context/wallet.context";
 import { toast } from "sonner";
 import AddressDisplay from "@/components/ui/AddressDisplay";
+import WalletStatePanel, {
+  WalletStateLoadingPanel,
+} from "@/components/wallet/WalletStatePanel";
+import { useWalletPageGate } from "@/hooks/useWalletPageGate";
 import { formatDate } from "@/lib/date";
 import { AlertCircle } from "lucide-react";
 
@@ -21,172 +24,185 @@ const MOCK_REQUESTS: VerificationRequest[] = [
   { id: "req_3", projectName: "Orbit NFT", submittedBy: "GHIJ...9012", status: "approved", timestamp: "2024-03-19T09:15:00Z" },
 ];
 
-/**
- * Admin authorization source: NEXT_PUBLIC_ADMIN_ALLOWLIST environment variable.
- * Provide a comma-separated list of authorized Stellar public keys.
- * Example: NEXT_PUBLIC_ADMIN_ALLOWLIST=GABC...1234,GDEF...5678
- */
 const ADMIN_ALLOWLIST = (process.env.NEXT_PUBLIC_ADMIN_ALLOWLIST ?? "")
   .split(",")
   .map((k) => k.trim())
   .filter(Boolean);
 
+const ADMIN_PURPOSE =
+  "Connect an authorized admin Freighter wallet to manage verification requests and system settings.";
+
 export default function AdminDashboard() {
-  const { isConnected, publicKey } = useWallet();
+  const gate = useWalletPageGate();
   const [requests, setRequests] = useState<VerificationRequest[]>(MOCK_REQUESTS);
   const [fee, setFee] = useState(1.5);
+
   const isAdmin = useMemo(
-    () => isConnected && Boolean(publicKey) && ADMIN_ALLOWLIST.includes(publicKey!),
-    [isConnected, publicKey],
+    () =>
+      gate.state === "ready" &&
+      Boolean(gate.publicKey) &&
+      ADMIN_ALLOWLIST.includes(gate.publicKey!),
+    [gate.state, gate.publicKey],
   );
-  const isAdminChecking = false;
 
   const handleAction = (id: string, status: "approved" | "rejected") => {
-    setRequests(prev => prev.map(req => 
-      req.id === id ? { ...req, status } : req
-    ));
+    setRequests((prev) =>
+      prev.map((req) => (req.id === id ? { ...req, status } : req)),
+    );
   };
 
   const handleSaveFee = () => {
-    // Persist / submit the fee here when the on-chain call is wired up.
     toast.success(`Verification fee updated to ${fee} XLM`);
   };
 
-  if (isAdminChecking) {
+  if (gate.state !== "ready") {
     return (
-      <div className="container mx-auto px-4 py-32 flex flex-col items-center justify-center text-center min-h-screen">
-        <p className="text-zinc-500 dark:text-zinc-400">Checking admin access…</p>
+      <div className="container mx-auto px-4 py-32 min-h-screen max-w-2xl">
+        {gate.state === "account-loading" ? (
+          <WalletStateLoadingPanel message="Verifying wallet access..." />
+        ) : (
+          <WalletStatePanel
+            state={gate.state}
+            pagePurpose={ADMIN_PURPOSE}
+            walletNetworkLabel={gate.walletNetworkLabel}
+            publicKey={gate.publicKey}
+            onConnect={gate.connectWallet}
+            onDisconnect={gate.disconnectWallet}
+          />
+        )}
       </div>
     );
   }
 
   if (!isAdmin) {
     return (
-        <div className="container mx-auto px-4 py-32 flex flex-col items-center justify-center text-center min-h-screen">
-          <div className="w-20 h-20 bg-red-100 dark:bg-red-900/20 rounded-full flex items-center justify-center text-red-500 mb-6">
-            <AlertCircle className="w-10 h-10" />
-          </div>
-          <h1 className="text-3xl font-bold mb-4">Access Restricted</h1>
-          <p className="text-zinc-500 dark:text-zinc-400 max-w-md mx-auto">
-            Please connect an authorized admin wallet to access this dashboard.
-          </p>
+      <div className="container mx-auto px-4 py-32 flex flex-col items-center justify-center text-center min-h-screen">
+        <div className="w-20 h-20 bg-red-100 dark:bg-red-900/20 rounded-full flex items-center justify-center text-red-500 mb-6">
+          <AlertCircle className="w-10 h-10" />
         </div>
+        <h1 className="text-3xl font-bold mb-4">Access Restricted</h1>
+        <p className="text-zinc-500 dark:text-zinc-400 max-w-md mx-auto">
+          Please connect an authorized admin wallet to access this dashboard.
+        </p>
+      </div>
     );
   }
 
   return (
-      <div className="container mx-auto px-4 py-12">
-        <div className="max-w-6xl mx-auto">
-          <header className="mb-12">
-            <h1 className="text-4xl font-black mb-2 tracking-tight">ADMIN DASHBOARD</h1>
-            <p className="text-zinc-500 dark:text-zinc-400">
-              Manage ecosystem verification and system parameters.
-            </p>
-          </header>
+    <div className="container mx-auto px-4 py-12">
+      <div className="max-w-6xl mx-auto">
+        <header className="mb-12">
+          <h1 className="text-4xl font-black mb-2 tracking-tight">ADMIN DASHBOARD</h1>
+          <p className="text-zinc-500 dark:text-zinc-400">
+            Manage ecosystem verification and system parameters.
+          </p>
+        </header>
 
-          <div className="grid grid-cols-1 lg:grid-cols-3 gap-8">
-            {/* Main Content: Requests */}
-            <div className="lg:col-span-2 space-y-6">
-              <h2 className="text-xl font-bold flex items-center gap-2">
-                <span className="w-2 h-8 bg-purple-500 rounded-full" />
-                Verification Requests
-              </h2>
-              
-              <div className="space-y-4">
-                {requests.map(req => (
-                  <div 
-                    key={req.id}
-                    className="bg-white dark:bg-zinc-900 border border-zinc-200 dark:border-zinc-800 p-6 rounded-3xl flex flex-col md:flex-row justify-between items-start md:items-center gap-4 transition-all hover:shadow-lg"
-                  >
-                    <div>
-                      <h3 className="font-bold text-lg mb-1">{req.projectName}</h3>
-                      <div className="text-xs text-zinc-500 font-mono flex items-center gap-1.5 flex-wrap">
-                        <span>Submitted by:</span>
-                        <AddressDisplay address={req.submittedBy} copyable={true} truncated={true} inline={true} />
-                        <span className="text-zinc-300 dark:text-zinc-700">•</span>
-                        <span>{formatDate(req.timestamp, "short")}</span>
-                      </div>
-                      <div className="mt-2">
-                        <span className={`text-[10px] uppercase font-bold px-2 py-1 rounded-full ${
-                          req.status === "pending" ? "bg-yellow-100 text-yellow-700 dark:bg-yellow-900/30 dark:text-yellow-500" :
-                          req.status === "approved" ? "bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-500" :
-                          "bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-500"
-                        }`}>
-                          {req.status}
-                        </span>
-                      </div>
+        <div className="grid grid-cols-1 lg:grid-cols-3 gap-8">
+          <div className="lg:col-span-2 space-y-6">
+            <h2 className="text-xl font-bold flex items-center gap-2">
+              <span className="w-2 h-8 bg-purple-500 rounded-full" />
+              Verification Requests
+            </h2>
+
+            <div className="space-y-4">
+              {requests.map((req) => (
+                <div
+                  key={req.id}
+                  className="bg-white dark:bg-zinc-900 border border-zinc-200 dark:border-zinc-800 p-6 rounded-3xl flex flex-col md:flex-row justify-between items-start md:items-center gap-4 transition-all hover:shadow-lg"
+                >
+                  <div>
+                    <h3 className="font-bold text-lg mb-1">{req.projectName}</h3>
+                    <div className="text-xs text-zinc-500 font-mono flex items-center gap-1.5 flex-wrap">
+                      <span>Submitted by:</span>
+                      <AddressDisplay address={req.submittedBy} copyable={true} truncated={true} inline={true} />
+                      <span className="text-zinc-300 dark:text-zinc-700">•</span>
+                      <span>{formatDate(req.timestamp, "short")}</span>
                     </div>
-
-                    {req.status === "pending" && (
-                      <div className="flex gap-2 w-full md:w-auto">
-                        <button
-                          onClick={() => handleAction(req.id, "approved")}
-                          className="flex-1 md:flex-none px-4 py-2 bg-green-500 hover:bg-green-600 text-white rounded-xl text-sm font-bold transition-colors"
-                        >
-                          Approve
-                        </button>
-                        <button
-                          onClick={() => handleAction(req.id, "rejected")}
-                          className="flex-1 md:flex-none px-4 py-2 bg-zinc-100 dark:bg-zinc-800 hover:bg-red-500 hover:text-white rounded-xl text-sm font-bold transition-all"
-                        >
-                          Reject
-                        </button>
-                      </div>
-                    )}
+                    <div className="mt-2">
+                      <span
+                        className={`text-[10px] uppercase font-bold px-2 py-1 rounded-full ${
+                          req.status === "pending"
+                            ? "bg-yellow-100 text-yellow-700 dark:bg-yellow-900/30 dark:text-yellow-500"
+                            : req.status === "approved"
+                              ? "bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-500"
+                              : "bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-500"
+                        }`}
+                      >
+                        {req.status}
+                      </span>
+                    </div>
                   </div>
-                ))}
+
+                  {req.status === "pending" && (
+                    <div className="flex gap-2 w-full md:w-auto">
+                      <button
+                        onClick={() => handleAction(req.id, "approved")}
+                        className="flex-1 md:flex-none px-4 py-2 bg-green-500 hover:bg-green-600 text-white rounded-xl text-sm font-bold transition-colors"
+                      >
+                        Approve
+                      </button>
+                      <button
+                        onClick={() => handleAction(req.id, "rejected")}
+                        className="flex-1 md:flex-none px-4 py-2 bg-zinc-100 dark:bg-zinc-800 hover:bg-red-500 hover:text-white rounded-xl text-sm font-bold transition-all"
+                      >
+                        Reject
+                      </button>
+                    </div>
+                  )}
+                </div>
+              ))}
+            </div>
+          </div>
+
+          <div className="space-y-6">
+            <h2 className="text-xl font-bold flex items-center gap-2">
+              <span className="w-2 h-8 bg-blue-500 rounded-full" />
+              System Settings
+            </h2>
+
+            <div className="bg-zinc-950 text-white p-8 rounded-3xl border border-zinc-800 shadow-2xl relative overflow-hidden group">
+              <div className="absolute top-0 right-0 w-32 h-32 bg-blue-500/10 blur-3xl rounded-full -mr-16 -mt-16 group-hover:bg-blue-500/20 transition-all" />
+
+              <h3 className="text-lg font-bold mb-6">Verification Fee</h3>
+              <div className="space-y-4">
+                <div className="flex items-end gap-3">
+                  <input
+                    type="number"
+                    value={fee}
+                    onChange={(e) => setFee(parseFloat(e.target.value))}
+                    className="bg-zinc-900 border border-zinc-800 rounded-2xl px-4 py-3 text-2xl font-black w-full outline-none focus:ring-2 focus:ring-blue-500"
+                  />
+                  <span className="text-xl font-bold mb-3">XLM</span>
+                </div>
+                <p className="text-xs text-zinc-500">
+                  This fee is charged to projects when they submit a verification request.
+                </p>
+                <button
+                  onClick={handleSaveFee}
+                  className="w-full py-4 bg-white text-black rounded-2xl font-black hover:bg-zinc-200 transition-colors"
+                >
+                  UPDATE FEE
+                </button>
               </div>
             </div>
 
-            {/* Sidebar: Settings */}
-            <div className="space-y-6">
-              <h2 className="text-xl font-bold flex items-center gap-2">
-                <span className="w-2 h-8 bg-blue-500 rounded-full" />
-                System Settings
-              </h2>
-              
-              <div className="bg-zinc-950 text-white p-8 rounded-3xl border border-zinc-800 shadow-2xl relative overflow-hidden group">
-                <div className="absolute top-0 right-0 w-32 h-32 bg-blue-500/10 blur-3xl rounded-full -mr-16 -mt-16 group-hover:bg-blue-500/20 transition-all" />
-                
-                <h3 className="text-lg font-bold mb-6">Verification Fee</h3>
-                <div className="space-y-4">
-                  <div className="flex items-end gap-3">
-                    <input
-                      type="number"
-                      value={fee}
-                      onChange={(e) => setFee(parseFloat(e.target.value))}
-                      className="bg-zinc-900 border border-zinc-800 rounded-2xl px-4 py-3 text-2xl font-black w-full outline-none focus:ring-2 focus:ring-blue-500"
-                    />
-                    <span className="text-xl font-bold mb-3">XLM</span>
-                  </div>
-                  <p className="text-xs text-zinc-500">
-                    This fee is charged to projects when they submit a verification request.
-                  </p>
-                  <button
-                    onClick={handleSaveFee}
-                    className="w-full py-4 bg-white text-black rounded-2xl font-black hover:bg-zinc-200 transition-colors"
-                  >
-                    UPDATE FEE
-                  </button>
+            <div className="bg-white dark:bg-zinc-900 border border-zinc-200 dark:border-zinc-800 p-6 rounded-3xl">
+              <h3 className="font-bold mb-4">Stats Overview</h3>
+              <div className="grid grid-cols-2 gap-4">
+                <div className="bg-zinc-50 dark:bg-zinc-800/50 p-4 rounded-2xl">
+                  <div className="text-xs text-zinc-500 uppercase font-bold mb-1">Active</div>
+                  <div className="text-2xl font-black">24</div>
                 </div>
-              </div>
-
-              <div className="bg-white dark:bg-zinc-900 border border-zinc-200 dark:border-zinc-800 p-6 rounded-3xl">
-                <h3 className="font-bold mb-4">Stats Overview</h3>
-                <div className="grid grid-cols-2 gap-4">
-                  <div className="bg-zinc-50 dark:bg-zinc-800/50 p-4 rounded-2xl">
-                    <div className="text-xs text-zinc-500 uppercase font-bold mb-1">Active</div>
-                    <div className="text-2xl font-black">24</div>
-                  </div>
-                  <div className="bg-zinc-50 dark:bg-zinc-800/50 p-4 rounded-2xl">
-                    <div className="text-xs text-zinc-500 uppercase font-bold mb-1">Queue</div>
-                    <div className="text-2xl font-black">12</div>
-                  </div>
+                <div className="bg-zinc-50 dark:bg-zinc-800/50 p-4 rounded-2xl">
+                  <div className="text-xs text-zinc-500 uppercase font-bold mb-1">Queue</div>
+                  <div className="text-2xl font-black">12</div>
                 </div>
               </div>
             </div>
           </div>
         </div>
       </div>
+    </div>
   );
 }

--- a/dongle/app/profile/page.tsx
+++ b/dongle/app/profile/page.tsx
@@ -40,31 +40,44 @@ export default function ProfilePage() {
   const gate = useWalletPageGate({ requireFundedAccount: true });
   const { balances } = useStellarAccount();
   const [verificationRequests, setVerificationRequests] = useState<VerificationRequest[]>([]);
-  const [loadingVerifications, setLoadingVerifications] = useState(false);
+  const [loadedVerificationKey, setLoadedVerificationKey] = useState<string | null>(null);
 
   const userReviews = gate.publicKey
     ? reviewService.getReviewsByUser(gate.publicKey)
     : [];
 
+  const displayedVerificationRequests = gate.publicKey ? verificationRequests : [];
+  const loadingVerifications =
+    Boolean(gate.publicKey) && loadedVerificationKey !== gate.publicKey;
+
   useEffect(() => {
     if (!gate.publicKey) {
-      setVerificationRequests([]);
       return;
     }
 
-    setLoadingVerifications(true);
-    verificationService
-      .getVerificationRequestsByUser(gate.publicKey)
-      .then((requests) => {
-        setVerificationRequests(requests);
-      })
-      .catch((err) => {
+    let cancelled = false;
+
+    void (async () => {
+      try {
+        const requests = await verificationService.getVerificationRequestsByUser(
+          gate.publicKey!,
+        );
+        if (!cancelled) {
+          setVerificationRequests(requests);
+          setLoadedVerificationKey(gate.publicKey);
+        }
+      } catch (err: unknown) {
         console.error("Error loading verification requests:", err);
-        setVerificationRequests([]);
-      })
-      .finally(() => {
-        setLoadingVerifications(false);
-      });
+        if (!cancelled) {
+          setVerificationRequests([]);
+          setLoadedVerificationKey(gate.publicKey);
+        }
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
   }, [gate.publicKey]);
 
   if (gate.state !== "ready") {
@@ -236,16 +249,16 @@ export default function ProfilePage() {
                     <Package className="w-6 h-6" />
                     Submitted Projects
                   </h2>
-                  <Badge variant="secondary">{verificationRequests.length}</Badge>
+                  <Badge variant="secondary">{displayedVerificationRequests.length}</Badge>
                 </div>
 
                 {loadingVerifications ? (
                   <div className="flex justify-center py-8">
                     <Spinner size="md" />
                   </div>
-                ) : verificationRequests.length > 0 ? (
+                ) : displayedVerificationRequests.length > 0 ? (
                   <div className="space-y-4">
-                    {verificationRequests.map((request) => {
+                    {displayedVerificationRequests.map((request) => {
                       const statusColors = {
                         PENDING: {
                           bg: "bg-yellow-50 dark:bg-yellow-900/20",
@@ -354,7 +367,7 @@ export default function ProfilePage() {
                       <Package className="w-4 h-4" />
                       Submitted
                     </span>
-                    <span className="font-bold text-lg">{verificationRequests.length}</span>
+                    <span className="font-bold text-lg">{displayedVerificationRequests.length}</span>
                   </div>
                 </div>
               </div>

--- a/dongle/app/profile/page.tsx
+++ b/dongle/app/profile/page.tsx
@@ -1,18 +1,19 @@
 "use client";
 
-import React, { useState, useEffect } from "react";
+import { useState, useEffect } from "react";
 import { useRouter } from "next/navigation";
 import LayoutWrapper from "@/components/layout/LayoutWrapper";
-import { useWallet } from "@/context/wallet.context";
-import { useStellarAccount } from "@/hooks/useStellarAccount";
 import { reviewService } from "@/services/review/review.service";
-import { projectService } from "@/services/project/project.service";
 import { verificationService, type VerificationRequest } from "@/services/stellar/verification.service";
 import { Button } from "@/components/ui/Button";
 import { Badge } from "@/components/ui/Badge";
 import { Spinner } from "@/components/ui/Spinner";
+import WalletStatePanel, {
+  WalletStateLoadingPanel,
+} from "@/components/wallet/WalletStatePanel";
+import { useWalletPageGate } from "@/hooks/useWalletPageGate";
+import { useStellarAccount } from "@/hooks/useStellarAccount";
 import {
-  Wallet,
   LogOut,
   Star,
   MessageSquare,
@@ -31,26 +32,29 @@ interface StellarNonNativeBalance {
   asset_issuer?: string;
 }
 
+const PROFILE_PURPOSE =
+  "Connect your Stellar wallet to view your profile, manage reviews, and track your activity on Dongle.";
+
 export default function ProfilePage() {
   const router = useRouter();
-  const { publicKey, isConnected, connectWallet, disconnectWallet } = useWallet();
-  const { balances, loading: accountLoading, error: accountError } = useStellarAccount();
+  const gate = useWalletPageGate({ requireFundedAccount: true });
+  const { balances } = useStellarAccount();
   const [verificationRequests, setVerificationRequests] = useState<VerificationRequest[]>([]);
   const [loadingVerifications, setLoadingVerifications] = useState(false);
 
-  // Get user's reviews
-  const userReviews = publicKey ? reviewService.getReviewsByUser(publicKey) : [];
+  const userReviews = gate.publicKey
+    ? reviewService.getReviewsByUser(gate.publicKey)
+    : [];
 
-  // Load verification requests when publicKey changes
   useEffect(() => {
-    if (!publicKey) {
+    if (!gate.publicKey) {
       setVerificationRequests([]);
       return;
     }
 
     setLoadingVerifications(true);
     verificationService
-      .getVerificationRequestsByUser(publicKey)
+      .getVerificationRequestsByUser(gate.publicKey)
       .then((requests) => {
         setVerificationRequests(requests);
       })
@@ -61,73 +65,25 @@ export default function ProfilePage() {
       .finally(() => {
         setLoadingVerifications(false);
       });
-  }, [publicKey]);
+  }, [gate.publicKey]);
 
-  // Disconnected state
-  if (!isConnected) {
+  if (gate.state !== "ready") {
     return (
       <LayoutWrapper>
         <main className="min-h-screen pt-32 pb-24 bg-zinc-50 dark:bg-zinc-950">
           <div className="container mx-auto px-4 max-w-2xl">
-            <div className="text-center py-24 bg-white dark:bg-zinc-900 rounded-3xl border border-zinc-200 dark:border-zinc-800">
-              <Wallet className="w-16 h-16 text-zinc-300 dark:text-zinc-700 mx-auto mb-4" />
-              <h1 className="text-3xl font-bold mb-2">Connect Your Wallet</h1>
-              <p className="text-zinc-500 dark:text-zinc-400 mb-8 max-w-md mx-auto">
-                Connect your Stellar wallet to view your profile, manage reviews, and track your activity on Dongle.
-              </p>
-              <Button
-                variant="primary"
-                size="lg"
-                onClick={connectWallet}
-                className="inline-flex items-center gap-2"
-              >
-                <Wallet className="w-5 h-5" />
-                Connect Wallet
-              </Button>
-            </div>
-          </div>
-        </main>
-      </LayoutWrapper>
-    );
-  }
-
-  // Loading state
-  if (accountLoading) {
-    return (
-      <LayoutWrapper>
-        <main className="min-h-screen pt-32 pb-24 bg-zinc-50 dark:bg-zinc-950">
-          <div className="container mx-auto px-4">
-            <div className="flex flex-col items-center justify-center py-24">
-              <Spinner size="lg" className="mb-4" />
-              <p className="text-zinc-500 dark:text-zinc-400">
-                Loading your profile...
-              </p>
-            </div>
-          </div>
-        </main>
-      </LayoutWrapper>
-    );
-  }
-
-  // Error state
-  if (accountError) {
-    return (
-      <LayoutWrapper>
-        <main className="min-h-screen pt-32 pb-24 bg-zinc-50 dark:bg-zinc-950">
-          <div className="container mx-auto px-4 max-w-2xl">
-            <div className="text-center py-24 bg-white dark:bg-zinc-900 rounded-3xl border border-zinc-200 dark:border-zinc-800">
-              <AlertCircle className="w-16 h-16 text-red-500 mx-auto mb-4" />
-              <h1 className="text-2xl font-bold mb-2">Account Not Found</h1>
-              <p className="text-zinc-500 dark:text-zinc-400 mb-6">
-                {accountError}
-              </p>
-              <Button
-                variant="outline"
-                onClick={() => disconnectWallet()}
-              >
-                Disconnect Wallet
-              </Button>
-            </div>
+            {gate.state === "account-loading" ? (
+              <WalletStateLoadingPanel message="Loading your profile..." />
+            ) : (
+              <WalletStatePanel
+                state={gate.state}
+                pagePurpose={PROFILE_PURPOSE}
+                walletNetworkLabel={gate.walletNetworkLabel}
+                publicKey={gate.publicKey}
+                onConnect={gate.connectWallet}
+                onDisconnect={gate.disconnectWallet}
+              />
+            )}
           </div>
         </main>
       </LayoutWrapper>
@@ -138,7 +94,6 @@ export default function ProfilePage() {
     <LayoutWrapper>
       <main className="min-h-screen pt-32 pb-24 bg-zinc-50 dark:bg-zinc-950">
         <div className="container mx-auto px-4 max-w-6xl">
-          {/* Header */}
           <div className="flex flex-col md:flex-row justify-between items-start md:items-center mb-12 gap-6">
             <div>
               <h1 className="text-4xl font-black mb-2 tracking-tight">
@@ -150,7 +105,7 @@ export default function ProfilePage() {
             </div>
             <Button
               variant="outline"
-              onClick={disconnectWallet}
+              onClick={gate.disconnectWallet}
               className="inline-flex items-center gap-2"
             >
               <LogOut className="w-4 h-4" />
@@ -159,20 +114,17 @@ export default function ProfilePage() {
           </div>
 
           <div className="grid grid-cols-1 lg:grid-cols-3 gap-8">
-            {/* Main Content */}
             <div className="lg:col-span-2 space-y-8">
-              {/* Account Summary */}
               <div className="bg-white dark:bg-zinc-900 border border-zinc-200 dark:border-zinc-800 rounded-3xl p-8">
                 <h2 className="text-2xl font-bold mb-6">Account Summary</h2>
 
-                {/* Wallet Address */}
                 <div className="mb-8">
                   <label className="text-sm font-medium text-zinc-500 dark:text-zinc-400 mb-2 block">
                     Wallet Address
                   </label>
                   <div className="flex items-center gap-2 bg-zinc-50 dark:bg-zinc-800 p-4 rounded-2xl">
                     <AddressDisplay
-                      address={publicKey!}
+                      address={gate.publicKey!}
                       copyable={true}
                       truncated={false}
                       inline={true}
@@ -181,7 +133,6 @@ export default function ProfilePage() {
                   </div>
                 </div>
 
-                {/* Balances */}
                 {balances && balances.length > 0 && (
                   <div>
                     <label className="text-sm font-medium text-zinc-500 dark:text-zinc-400 mb-4 block">
@@ -224,7 +175,6 @@ export default function ProfilePage() {
                 )}
               </div>
 
-              {/* User Reviews */}
               <div className="bg-white dark:bg-zinc-900 border border-zinc-200 dark:border-zinc-800 rounded-3xl p-8">
                 <div className="flex items-center justify-between mb-6">
                   <h2 className="text-2xl font-bold flex items-center gap-2">
@@ -280,7 +230,6 @@ export default function ProfilePage() {
                 )}
               </div>
 
-              {/* Verification Requests */}
               <div className="bg-white dark:bg-zinc-900 border border-zinc-200 dark:border-zinc-800 rounded-3xl p-8">
                 <div className="flex items-center justify-between mb-6">
                   <h2 className="text-2xl font-bold flex items-center gap-2">
@@ -373,12 +322,9 @@ export default function ProfilePage() {
                   </div>
                 )}
               </div>
-
             </div>
 
-            {/* Sidebar */}
             <div className="space-y-6">
-              {/* Stats */}
               <div className="bg-white dark:bg-zinc-900 border border-zinc-200 dark:border-zinc-800 rounded-3xl p-6">
                 <h3 className="text-lg font-bold mb-4">Activity Stats</h3>
                 <div className="space-y-4">
@@ -413,7 +359,6 @@ export default function ProfilePage() {
                 </div>
               </div>
 
-              {/* Quick Actions */}
               <div className="bg-white dark:bg-zinc-900 border border-zinc-200 dark:border-zinc-800 rounded-3xl p-6">
                 <h3 className="text-lg font-bold mb-4">Quick Actions</h3>
                 <div className="space-y-3">

--- a/dongle/app/projects/new/page.tsx
+++ b/dongle/app/projects/new/page.tsx
@@ -2,65 +2,65 @@
 
 import React from "react";
 import ProjectForm from "@/components/projects/ProjectForm";
-import { useWallet } from "@/context/wallet.context";
-import { Wallet2, ShieldCheck, Zap, Rocket } from "lucide-react";
-import { Button } from "@/components/ui/Button";
+import WalletStatePanel, {
+  WalletStateLoadingPanel,
+} from "@/components/wallet/WalletStatePanel";
+import { useWalletPageGate } from "@/hooks/useWalletPageGate";
+import { ShieldCheck, Zap, Rocket } from "lucide-react";
 import { Card } from "@/components/ui/Card";
 
+const SUBMIT_PURPOSE =
+  "Connect Freighter to register a new project on Dongle with an on-chain transaction.";
+
 export default function NewProjectPage() {
-  const { isConnected, isConnecting, connectWallet } = useWallet();
+  const gate = useWalletPageGate();
 
   return (
     <main className="min-h-screen pt-32 pb-24 bg-[radial-gradient(ellipse_at_top,var(--tw-gradient-stops))] from-blue-500/5 via-transparent to-transparent">
       <div className="container mx-auto px-4">
-        {!isConnected ? (
-          <div className="max-w-xl mx-auto text-center py-20 animate-fade-in">
-            <div className="inline-flex p-4 bg-zinc-100 dark:bg-zinc-900 rounded-3xl mb-8 border border-zinc-200 dark:border-zinc-800">
-              <Wallet2 className="w-8 h-8 text-blue-500" />
-            </div>
-            <h1 className="text-4xl font-bold mb-6 tracking-tight">
-              Connect your wallet to get started
-            </h1>
-            <p className="text-zinc-500 dark:text-zinc-400 mb-10 text-lg">
-              To register a new project on Dongle, you need to sign an on-chain
-              transaction with your Stellar wallet.
-            </p>
-            <Button
-              onClick={connectWallet}
-              size="lg"
-              className="px-10"
-              isLoading={isConnecting}
-              disabled={isConnecting}
-            >
-              {isConnecting ? "Connecting..." : "Connect Wallet"}
-            </Button>
-
-            <div className="grid grid-cols-1 md:grid-cols-3 gap-6 mt-20">
-              <Card className="text-left">
-                <ShieldCheck className="w-6 h-6 text-green-500 mb-3" />
-                <h3 className="font-bold mb-1">Secure</h3>
-                <p className="text-xs text-zinc-500">
-                  Your keys never leave Freighter.
-                </p>
-              </Card>
-              <Card className="text-left">
-                <Zap className="w-6 h-6 text-yellow-500 mb-3" />
-                <h3 className="font-bold mb-1">Fast</h3>
-                <p className="text-xs text-zinc-500">
-                  Transactions settle in seconds.
-                </p>
-              </Card>
-              <Card className="text-left">
-                <Rocket className="w-6 h-6 text-blue-500 mb-3" />
-                <h3 className="font-bold mb-1">Direct</h3>
-                <p className="text-xs text-zinc-500">
-                  Register directly on-chain.
-                </p>
-              </Card>
-            </div>
-          </div>
-        ) : (
+        {gate.state === "ready" ? (
           <ProjectForm />
+        ) : (
+          <div className="max-w-xl mx-auto animate-fade-in">
+            {gate.state === "account-loading" ? (
+              <WalletStateLoadingPanel message="Preparing your wallet..." />
+            ) : (
+              <WalletStatePanel
+                state={gate.state}
+                pagePurpose={SUBMIT_PURPOSE}
+                walletNetworkLabel={gate.walletNetworkLabel}
+                publicKey={gate.publicKey}
+                onConnect={gate.connectWallet}
+                onDisconnect={gate.disconnectWallet}
+              />
+            )}
+
+            {gate.state === "disconnected" && (
+              <div className="grid grid-cols-1 md:grid-cols-3 gap-6 mt-12">
+                <Card className="text-left">
+                  <ShieldCheck className="w-6 h-6 text-green-500 mb-3" />
+                  <h3 className="font-bold mb-1">Secure</h3>
+                  <p className="text-xs text-zinc-500">
+                    Your keys never leave Freighter.
+                  </p>
+                </Card>
+                <Card className="text-left">
+                  <Zap className="w-6 h-6 text-yellow-500 mb-3" />
+                  <h3 className="font-bold mb-1">Fast</h3>
+                  <p className="text-xs text-zinc-500">
+                    Transactions settle in seconds.
+                  </p>
+                </Card>
+                <Card className="text-left">
+                  <Rocket className="w-6 h-6 text-blue-500 mb-3" />
+                  <h3 className="font-bold mb-1">Direct</h3>
+                  <p className="text-xs text-zinc-500">
+                    Register directly on-chain.
+                  </p>
+                </Card>
+              </div>
+            )}
+          </div>
         )}
       </div>
     </main>

--- a/dongle/app/reviews/page.tsx
+++ b/dongle/app/reviews/page.tsx
@@ -1,17 +1,22 @@
 "use client";
 
 import { useState, useMemo } from "react";
-import { useWallet } from "@/context/wallet.context";
 import { reviewService } from "@/services/review/review.service";
 import { Review, Project } from "@/types/review";
 import ReviewList from "@/components/reviews/ReviewList";
 import ReviewForm from "@/components/reviews/ReviewForm";
 import { mockProjects } from "@/data/mockProjects";
 import { toast } from "sonner";
+import WalletStatePanel, {
+  WalletDisconnectedBanner,
+} from "@/components/wallet/WalletStatePanel";
+import { useWalletPageGate } from "@/hooks/useWalletPageGate";
+
+const REVIEWS_PURPOSE =
+  "Connect Freighter to post, edit, or delete your community reviews on Dongle.";
 
 export default function ReviewsPage() {
-  const { isConnected, publicKey, connectWallet } = useWallet();
-  // Lazy initializer — reads from service once on mount, no effect needed
+  const gate = useWalletPageGate();
   const [reviews, setReviews] = useState<Review[]>(() =>
     reviewService.getReviews(),
   );
@@ -19,17 +24,23 @@ export default function ReviewsPage() {
   const [editingReview, setEditingReview] = useState<Review | null>(null);
   const [selectedProject, setSelectedProject] = useState<Project | null>(null);
   const [sortBy, setSortBy] = useState<"recent" | "helpfulness">("recent");
+  const [showWalletGate, setShowWalletGate] = useState(false);
 
   const handleAddReview = (project: Project) => {
-    if (!isConnected) {
-      connectWallet();
+    if (gate.state !== "ready") {
+      setShowWalletGate(true);
       return;
     }
     setSelectedProject(project);
     setIsAddingReview(true);
+    setShowWalletGate(false);
   };
 
   const handleEditReview = (review: Review) => {
+    if (gate.state !== "ready") {
+      setShowWalletGate(true);
+      return;
+    }
     setEditingReview(review);
     const project = mockProjects.find((p) => p.id === review.projectId) || {
       id: review.projectId,
@@ -43,9 +54,12 @@ export default function ReviewsPage() {
   };
 
   const handleDeleteReview = (id: string) => {
-    if (!publicKey) return;
+    if (!gate.publicKey) {
+      setShowWalletGate(true);
+      return;
+    }
     if (confirm("Are you sure you want to delete this review?")) {
-      const result = reviewService.deleteReview(id, publicKey);
+      const result = reviewService.deleteReview(id, gate.publicKey);
       if (result.success) {
         setReviews(reviewService.getReviews());
         toast.success("Review deleted");
@@ -56,11 +70,11 @@ export default function ReviewsPage() {
   };
 
   const handleVoteHelpful = (id: string) => {
-    if (!publicKey) {
+    if (!gate.publicKey) {
       toast.error("Please connect your wallet to vote");
       return;
     }
-    const result = reviewService.voteHelpful(id, publicKey);
+    const result = reviewService.voteHelpful(id, gate.publicKey);
     if (result.success) {
       setReviews(reviewService.getReviews());
     } else {
@@ -69,11 +83,11 @@ export default function ReviewsPage() {
   };
 
   const handleVoteUnhelpful = (id: string) => {
-    if (!publicKey) {
+    if (!gate.publicKey) {
       toast.error("Please connect your wallet to vote");
       return;
     }
-    const result = reviewService.voteUnhelpful(id, publicKey);
+    const result = reviewService.voteUnhelpful(id, gate.publicKey);
     if (result.success) {
       setReviews(reviewService.getReviews());
     } else {
@@ -82,10 +96,10 @@ export default function ReviewsPage() {
   };
 
   const handleSubmit = (data: { rating: number; comment: string }) => {
-    if (!publicKey || !selectedProject) return;
+    if (!gate.publicKey || !selectedProject) return;
 
     if (editingReview) {
-      const result = reviewService.updateReview(editingReview.id, data, publicKey);
+      const result = reviewService.updateReview(editingReview.id, data, gate.publicKey);
       if (result.success) {
         setReviews(reviewService.getReviews());
         setIsAddingReview(false);
@@ -100,10 +114,10 @@ export default function ReviewsPage() {
         {
           projectId: selectedProject.id,
           projectName: selectedProject.name,
-          userAddress: publicKey,
+          userAddress: gate.publicKey,
           ...data,
         },
-        publicKey
+        gate.publicKey,
       );
       if (result.success) {
         setReviews(reviewService.getReviews());
@@ -132,6 +146,9 @@ export default function ReviewsPage() {
     return list.sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime());
   }, [reviews, sortBy]);
 
+  const walletBlocked =
+    showWalletGate && gate.state !== "ready" && gate.state !== "account-loading";
+
   return (
     <div className="container mx-auto px-4 py-12">
       <div className="max-w-4xl mx-auto">
@@ -144,7 +161,7 @@ export default function ReviewsPage() {
               Transparent feedback from the Stellar ecosystem.
             </p>
           </div>
-          {!isAddingReview && !editingReview && (
+          {!isAddingReview && !editingReview && gate.state === "ready" && (
             <div className="flex gap-2">
               {mockProjects.slice(0, 6).map((p) => (
                 <button
@@ -159,12 +176,36 @@ export default function ReviewsPage() {
           )}
         </div>
 
-        {(isAddingReview || editingReview) && selectedProject && (
+        {gate.state === "disconnected" && !walletBlocked && (
+          <WalletDisconnectedBanner
+            pagePurpose={REVIEWS_PURPOSE}
+            onConnect={gate.connectWallet}
+            isConnecting={gate.isConnecting}
+          />
+        )}
+
+        {walletBlocked &&
+          gate.state !== "ready" &&
+          gate.state !== "account-loading" && (
+          <div className="mb-12">
+            <WalletStatePanel
+              state={gate.state}
+              pagePurpose={REVIEWS_PURPOSE}
+              walletNetworkLabel={gate.walletNetworkLabel}
+              publicKey={gate.publicKey}
+              onConnect={gate.connectWallet}
+              onDisconnect={gate.disconnectWallet}
+              compact
+            />
+          </div>
+        )}
+
+        {(isAddingReview || editingReview) && selectedProject && gate.state === "ready" && (
           <div className="mb-12">
             <ReviewForm
               projectId={selectedProject.id}
               projectName={selectedProject.name}
-              userAddress={publicKey || ""}
+              userAddress={gate.publicKey || ""}
               initialReview={editingReview || undefined}
               onSubmit={handleSubmit}
               onCancel={() => {
@@ -198,7 +239,7 @@ export default function ReviewsPage() {
 
             <ReviewList
               reviews={sortedReviews}
-              currentUserAddress={publicKey}
+              currentUserAddress={gate.publicKey}
               onEdit={handleEditReview}
               onDelete={handleDeleteReview}
               onVoteHelpful={handleVoteHelpful}

--- a/dongle/components/projects/ProjectForm.tsx
+++ b/dongle/components/projects/ProjectForm.tsx
@@ -20,7 +20,7 @@ import { normalizeUrl, extractDomain } from "@/lib/url";
 const urlSchema = z.string().transform((val, ctx) => {
   try {
     return normalizeUrl(val);
-  } catch (err: any) {
+  } catch {
     ctx.addIssue({
       code: z.ZodIssueCode.custom,
       message: "Please enter a valid URL",
@@ -33,7 +33,7 @@ const optionalUrlSchema = z.string().transform((val, ctx) => {
   if (val.trim().length === 0) return "";
   try {
     return normalizeUrl(val);
-  } catch (err: any) {
+  } catch {
     ctx.addIssue({
       code: z.ZodIssueCode.custom,
       message: "Please enter a valid URL",

--- a/dongle/components/wallet/WalletStatePanel.tsx
+++ b/dongle/components/wallet/WalletStatePanel.tsx
@@ -1,0 +1,191 @@
+"use client";
+
+import React from "react";
+import {
+  AlertCircle,
+  AlertTriangle,
+  Download,
+  Loader2,
+  Wallet,
+  WifiOff,
+} from "lucide-react";
+import { Button } from "@/components/ui/Button";
+import { Spinner } from "@/components/ui/Spinner";
+import {
+  getWalletStateContent,
+  type WalletPageState,
+} from "@/components/wallet/wallet-states";
+
+interface WalletStatePanelProps {
+  state: Exclude<WalletPageState, "ready" | "account-loading">;
+  pagePurpose?: string;
+  walletNetworkLabel?: string;
+  publicKey?: string | null;
+  onConnect?: () => void;
+  onDisconnect?: () => void;
+  compact?: boolean;
+  className?: string;
+}
+
+const STATE_ICONS: Record<
+  Exclude<WalletPageState, "ready" | "account-loading">,
+  React.ReactNode
+> = {
+  "freighter-missing": <Download className="w-16 h-16 text-blue-500" />,
+  connecting: <Loader2 className="w-16 h-16 text-blue-500 animate-spin" />,
+  disconnected: <Wallet className="w-16 h-16 text-zinc-300 dark:text-zinc-700" />,
+  "wrong-network": <AlertTriangle className="w-16 h-16 text-amber-500" />,
+  "account-not-funded": <AlertCircle className="w-16 h-16 text-amber-500" />,
+};
+
+export default function WalletStatePanel({
+  state,
+  pagePurpose,
+  walletNetworkLabel,
+  publicKey,
+  onConnect,
+  onDisconnect,
+  compact = false,
+  className = "",
+}: WalletStatePanelProps) {
+  const content = getWalletStateContent(state, {
+    pagePurpose,
+    walletNetworkLabel,
+    publicKey,
+  });
+
+  const padding = compact ? "py-12 px-6" : "py-24 px-8";
+
+  const actionClassName =
+    "inline-flex items-center justify-center gap-2 transition-all active:scale-[0.98] font-medium";
+
+  const renderAction = (
+    action: NonNullable<typeof content.primaryAction>,
+    variant: "primary" | "outline" = "primary",
+    onClick?: () => void,
+  ) => {
+    if (action.href) {
+      return (
+        <a
+          href={action.href}
+          target={action.external ? "_blank" : undefined}
+          rel={action.external ? "noopener noreferrer" : undefined}
+          className={`${actionClassName} ${
+            variant === "primary"
+              ? "bg-zinc-900 dark:bg-white text-white dark:text-zinc-900 hover:opacity-90 px-8 py-4 text-lg rounded-[1.5rem] font-bold"
+              : "bg-transparent border border-zinc-200 dark:border-zinc-800 text-zinc-900 dark:text-white hover:bg-zinc-50 dark:hover:bg-zinc-900 px-6 py-3 text-base rounded-2xl"
+          } ${compact ? "!px-6 !py-3 !text-base !rounded-2xl" : ""}`}
+        >
+          {action.label}
+        </a>
+      );
+    }
+
+    return (
+      <Button
+        variant={variant}
+        size={compact ? "md" : "lg"}
+        className="inline-flex items-center gap-2"
+        onClick={onClick}
+        isLoading={state === "connecting"}
+        disabled={state === "connecting"}
+      >
+        {state === "disconnected" && <Wallet className="w-5 h-5" />}
+        {action.label}
+      </Button>
+    );
+  };
+
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      className={`text-center bg-white dark:bg-zinc-900 rounded-3xl border border-zinc-200 dark:border-zinc-800 ${padding} ${className}`}
+    >
+      <div className="flex justify-center mb-4" aria-hidden="true">
+        {STATE_ICONS[state]}
+      </div>
+      <h2 className={`font-bold mb-2 ${compact ? "text-2xl" : "text-3xl"}`}>
+        {content.title}
+      </h2>
+      <p className="text-zinc-500 dark:text-zinc-400 mb-8 max-w-md mx-auto">
+        {content.description}
+      </p>
+      <div className="flex flex-col sm:flex-row items-center justify-center gap-3">
+        {content.primaryAction &&
+          renderAction(
+            content.primaryAction,
+            "primary",
+            state === "disconnected" ? onConnect : undefined,
+          )}
+        {content.secondaryAction &&
+          renderAction(
+            content.secondaryAction,
+            "outline",
+            state === "account-not-funded" ? onDisconnect : undefined,
+          )}
+      </div>
+      {state === "freighter-missing" && (
+        <p className="mt-6 text-xs text-zinc-400">
+          After installing Freighter, refresh this page and connect your wallet.
+        </p>
+      )}
+    </div>
+  );
+}
+
+export function WalletStateLoadingPanel({
+  message = "Loading wallet data...",
+  className = "",
+}: {
+  message?: string;
+  className?: string;
+}) {
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      className={`flex flex-col items-center justify-center py-24 ${className}`}
+    >
+      <Spinner size="lg" className="mb-4" />
+      <p className="text-zinc-500 dark:text-zinc-400">{message}</p>
+    </div>
+  );
+}
+
+export function WalletDisconnectedBanner({
+  pagePurpose,
+  onConnect,
+  isConnecting,
+}: {
+  pagePurpose?: string;
+  onConnect?: () => void;
+  isConnecting?: boolean;
+}) {
+  return (
+    <div
+      role="status"
+      className="mb-8 flex flex-col sm:flex-row items-start sm:items-center gap-4 p-4 rounded-2xl border border-zinc-200 dark:border-zinc-800 bg-zinc-50 dark:bg-zinc-900/50"
+    >
+      <WifiOff className="w-5 h-5 shrink-0 text-zinc-400 mt-0.5" aria-hidden="true" />
+      <div className="flex-1 text-left">
+        <p className="font-semibold text-zinc-900 dark:text-zinc-100">
+          Wallet not connected
+        </p>
+        <p className="text-sm text-zinc-500 dark:text-zinc-400">
+          {pagePurpose ??
+            "Connect Freighter to post reviews and manage your on-chain activity."}
+        </p>
+      </div>
+      <Button
+        variant="primary"
+        size="sm"
+        onClick={onConnect}
+        isLoading={isConnecting}
+        disabled={isConnecting}
+      >
+        Connect Wallet
+      </Button>
+    </div>
+  );
+}

--- a/dongle/components/wallet/wallet-states.ts
+++ b/dongle/components/wallet/wallet-states.ts
@@ -1,0 +1,113 @@
+import { EXPECTED_NETWORK_LABEL } from "@/context/wallet.context";
+
+export const FREIGHTER_INSTALL_URL = "https://www.freighter.app/";
+export const FRIENDBOT_BASE_URL = "https://friendbot.stellar.org";
+
+export type WalletPageState =
+  | "ready"
+  | "freighter-missing"
+  | "connecting"
+  | "disconnected"
+  | "wrong-network"
+  | "account-loading"
+  | "account-not-funded";
+
+export interface WalletStateContent {
+  title: string;
+  description: string;
+  primaryAction?: {
+    label: string;
+    href?: string;
+    external?: boolean;
+  };
+  secondaryAction?: {
+    label: string;
+    href?: string;
+    external?: boolean;
+  };
+}
+
+export function getFriendbotUrl(publicKey: string): string {
+  return `${FRIENDBOT_BASE_URL}?addr=${encodeURIComponent(publicKey)}`;
+}
+
+export function isAccountNotFundedError(error: string | null | undefined): boolean {
+  if (!error) return false;
+  const normalized = error.toLowerCase();
+  return (
+    normalized.includes("account not found") ||
+    normalized.includes("not funded") ||
+    normalized.includes("friendbot")
+  );
+}
+
+export function getWalletStateContent(
+  state: Exclude<WalletPageState, "ready" | "account-loading">,
+  options: {
+    walletNetworkLabel?: string;
+    publicKey?: string | null;
+    pagePurpose?: string;
+  } = {},
+): WalletStateContent {
+  const purpose =
+    options.pagePurpose ??
+    "Connect your Stellar wallet to use this page on Dongle.";
+
+  switch (state) {
+    case "freighter-missing":
+      return {
+        title: "Install Freighter Wallet",
+        description:
+          "Dongle uses Freighter, the Stellar browser extension, to connect your wallet and sign transactions securely.",
+        primaryAction: {
+          label: "Get Freighter",
+          href: FREIGHTER_INSTALL_URL,
+          external: true,
+        },
+      };
+    case "connecting":
+      return {
+        title: "Connecting Wallet",
+        description: "Approve the connection request in your Freighter extension.",
+      };
+    case "disconnected":
+      return {
+        title: "Connect Your Wallet",
+        description: purpose,
+        primaryAction: {
+          label: "Connect Wallet",
+        },
+      };
+    case "wrong-network":
+      return {
+        title: "Wrong Network",
+        description: `Your Freighter wallet is on ${options.walletNetworkLabel ?? "an unsupported network"}. Switch to ${EXPECTED_NETWORK_LABEL} in Freighter (Settings → Network) before continuing.`,
+        primaryAction: {
+          label: "Open Freighter Docs",
+          href: "https://developers.stellar.org/docs/build/guides/freighter/connect-testnet",
+          external: true,
+        },
+      };
+    case "account-not-funded":
+      return {
+        title: "Fund Your Testnet Account",
+        description:
+          "Your wallet address is not funded on Stellar Testnet yet. Use Friendbot to receive free test XLM, then return here.",
+        primaryAction: options.publicKey
+          ? {
+              label: "Fund with Friendbot",
+              href: getFriendbotUrl(options.publicKey),
+              external: true,
+            }
+          : undefined,
+        secondaryAction: {
+          label: "Disconnect Wallet",
+        },
+      };
+    default:
+      return {
+        title: "Wallet Required",
+        description: purpose,
+      };
+  }
+}

--- a/dongle/context/wallet.context.tsx
+++ b/dongle/context/wallet.context.tsx
@@ -34,6 +34,8 @@ interface WalletContextType {
   publicKey: string | null;
   isConnected: boolean;
   isConnecting: boolean;
+  /** null while checking, false when Freighter is not installed. */
+  isFreighterAvailable: boolean | null;
   /** Passphrase of the network currently active in the wallet, or null when not connected. */
   walletNetwork: string | null;
   /** True when the wallet is connected AND on the expected network. */
@@ -54,6 +56,7 @@ export function WalletProvider({ children }: { children: ReactNode }) {
   const [publicKey, setPublicKey] = useState<string | null>(null);
   const [isConnected, setIsConnected] = useState<boolean>(false);
   const [isConnecting, setIsConnecting] = useState<boolean>(false);
+  const [isFreighterAvailable, setIsFreighterAvailable] = useState<boolean | null>(null);
   const [walletNetwork, setWalletNetwork] = useState<string | null>(null);
 
   const isCorrectNetwork =
@@ -70,6 +73,11 @@ export function WalletProvider({ children }: { children: ReactNode }) {
     setWalletNetwork(null);
     localStorage.removeItem(WALLET_STORAGE_KEY);
     toast.success("Wallet disconnected");
+  }, []);
+
+  // ── detect Freighter on mount ──────────────────────────────────────────────
+  useEffect(() => {
+    void walletService.isFreighterAvailable().then(setIsFreighterAvailable);
   }, []);
 
   // ── restore on mount ───────────────────────────────────────────────────────
@@ -183,6 +191,7 @@ export function WalletProvider({ children }: { children: ReactNode }) {
         publicKey,
         isConnected,
         isConnecting,
+        isFreighterAvailable,
         walletNetwork,
         isCorrectNetwork,
         walletNetworkLabel,

--- a/dongle/hooks/useWalletPageGate.ts
+++ b/dongle/hooks/useWalletPageGate.ts
@@ -1,0 +1,122 @@
+"use client";
+
+import { useWallet } from "@/context/wallet.context";
+import { useStellarAccount } from "@/hooks/useStellarAccount";
+import {
+  isAccountNotFundedError,
+  type WalletPageState,
+} from "@/components/wallet/wallet-states";
+
+export interface UseWalletPageGateOptions {
+  /** When true, blocks on unfunded/missing Horizon account. */
+  requireFundedAccount?: boolean;
+}
+
+export interface WalletPageGateResult {
+  state: WalletPageState;
+  publicKey: string | null;
+  walletNetworkLabel: string;
+  connectWallet: () => Promise<void>;
+  disconnectWallet: () => void;
+  isConnecting: boolean;
+}
+
+/**
+ * Resolves the wallet gate state for pages that depend on wallet connectivity.
+ * Priority: freighter missing → connecting → disconnected → wrong network →
+ * account loading → account not funded → ready.
+ */
+export function useWalletPageGate(
+  options: UseWalletPageGateOptions = {},
+): WalletPageGateResult {
+  const { requireFundedAccount = false } = options;
+  const {
+    publicKey,
+    isConnected,
+    isConnecting,
+    isCorrectNetwork,
+    walletNetworkLabel,
+    isFreighterAvailable,
+    connectWallet,
+    disconnectWallet,
+  } = useWallet();
+
+  const { loading: accountLoading, error: accountError } = useStellarAccount();
+
+  if (isFreighterAvailable === false) {
+    return {
+      state: "freighter-missing",
+      publicKey,
+      walletNetworkLabel,
+      connectWallet,
+      disconnectWallet,
+      isConnecting,
+    };
+  }
+
+  if (isConnecting) {
+    return {
+      state: "connecting",
+      publicKey,
+      walletNetworkLabel,
+      connectWallet,
+      disconnectWallet,
+      isConnecting,
+    };
+  }
+
+  if (!isConnected) {
+    return {
+      state: "disconnected",
+      publicKey,
+      walletNetworkLabel,
+      connectWallet,
+      disconnectWallet,
+      isConnecting,
+    };
+  }
+
+  if (!isCorrectNetwork) {
+    return {
+      state: "wrong-network",
+      publicKey,
+      walletNetworkLabel,
+      connectWallet,
+      disconnectWallet,
+      isConnecting,
+    };
+  }
+
+  if (requireFundedAccount) {
+    if (accountLoading) {
+      return {
+        state: "account-loading",
+        publicKey,
+        walletNetworkLabel,
+        connectWallet,
+        disconnectWallet,
+        isConnecting,
+      };
+    }
+
+    if (isAccountNotFundedError(accountError)) {
+      return {
+        state: "account-not-funded",
+        publicKey,
+        walletNetworkLabel,
+        connectWallet,
+        disconnectWallet,
+        isConnecting,
+      };
+    }
+  }
+
+  return {
+    state: "ready",
+    publicKey,
+    walletNetworkLabel,
+    connectWallet,
+    disconnectWallet,
+    isConnecting,
+  };
+}

--- a/dongle/lib/url.ts
+++ b/dongle/lib/url.ts
@@ -19,7 +19,7 @@ export function normalizeUrl(urlStr: string): string {
   let parsed: URL;
   try {
     parsed = new URL(cleaned);
-  } catch (e) {
+  } catch {
     throw new Error("Invalid URL structure");
   }
 
@@ -57,7 +57,7 @@ export function extractDomain(urlStr: string): string {
     const normalized = normalizeUrl(urlStr);
     const parsed = new URL(normalized);
     return parsed.hostname.replace(/^www\./i, "");
-  } catch (e) {
+  } catch {
     return "";
   }
 }

--- a/dongle/services/review/review.service.ts
+++ b/dongle/services/review/review.service.ts
@@ -53,10 +53,10 @@ export const reviewService = {
     const stored = localStorage.getItem(STORAGE_KEY);
     if (!stored) return [];
 
-    let parsed: any;
+    let parsed: unknown;
     try {
       parsed = JSON.parse(stored);
-    } catch (e) {
+    } catch {
       return [];
     }
 
@@ -70,56 +70,59 @@ export const reviewService = {
         continue;
       }
 
+      const record = item as Record<string, unknown>;
+
       // Must have projectId and userAddress as strings
-      if (typeof item.projectId !== "string" || !item.projectId) {
+      if (typeof record.projectId !== "string" || !record.projectId) {
         continue;
       }
-      if (typeof item.userAddress !== "string" || !item.userAddress) {
+      if (typeof record.userAddress !== "string" || !record.userAddress) {
         continue;
       }
 
       // Rating must be a number
-      const rawRating = Number(item.rating);
+      const rawRating = Number(record.rating);
       if (isNaN(rawRating)) {
         continue;
       }
       const rating = Math.max(1, Math.min(5, Math.round(rawRating)));
 
       // Comment must be a string
-      if (typeof item.comment !== "string") {
+      if (typeof record.comment !== "string") {
         continue;
       }
 
       // Migrate / fallback fields
-      const id = typeof item.id === "string" && item.id ? item.id : generateId();
-      const projectName = typeof item.projectName === "string" && item.projectName ? item.projectName : "Unknown Project";
+      const id = typeof record.id === "string" && record.id ? record.id : generateId();
+      const projectName = typeof record.projectName === "string" && record.projectName ? record.projectName : "Unknown Project";
       
-      let createdAt = item.createdAt;
-      if (typeof createdAt !== "string" || isNaN(Date.parse(createdAt))) {
+      let createdAt: string;
+      if (typeof record.createdAt === "string" && !isNaN(Date.parse(record.createdAt))) {
+        createdAt = record.createdAt;
+      } else {
         createdAt = new Date().toISOString();
       }
 
       const review: Review = {
         id,
-        projectId: item.projectId,
+        projectId: record.projectId,
         projectName,
-        userAddress: item.userAddress,
+        userAddress: record.userAddress,
         rating,
-        comment: item.comment,
+        comment: record.comment,
         createdAt,
       };
 
-      // Support for helpful/unhelpful votes for task 3
-      if (Array.isArray(item.helpfulVotes)) {
-        (review as any).helpfulVotes = item.helpfulVotes.filter((v: any) => typeof v === "string");
+      if (Array.isArray(record.helpfulVotes)) {
+        review.helpfulVotes = record.helpfulVotes.filter((v): v is string => typeof v === "string");
       } else {
-        (review as any).helpfulVotes = [];
+        review.helpfulVotes = [];
       }
 
-      if (Array.isArray(item.unhelpfulVotes)) {
-        (review as any).unhelpfulVotes = item.unhelpfulVotes.filter((v: any) => typeof v === "string");
+      if (Array.isArray(record.unhelpfulVotes)) {
+        review.unhelpfulVotes = record.unhelpfulVotes.filter((v): v is string => typeof v === "string");
       } else {
-        (review as any).unhelpfulVotes = [];
+        review.unhelpfulVotes = [];
       }
 
       validatedReviews.push(review);

--- a/dongle/services/stellar/verification.service.ts
+++ b/dongle/services/stellar/verification.service.ts
@@ -94,6 +94,24 @@ class VerificationService {
   }
 
   /**
+   * Gets all verification requests submitted by a user (for profile page).
+   */
+  async getVerificationRequestsByUser(submittedBy: string): Promise<VerificationRequest[]> {
+    try {
+      const requests = this.loadRequests();
+      return requests
+        .filter((r) => r.submittedBy === submittedBy)
+        .sort(
+          (a, b) =>
+            new Date(b.submittedAt).getTime() - new Date(a.submittedAt).getTime(),
+        );
+    } catch (error) {
+      console.error("[VerificationService] Error getting user requests:", error);
+      return [];
+    }
+  }
+
+  /**
    * Gets all pending verification requests (for admin dashboard).
    */
   async getPendingRequests(): Promise<VerificationRequest[]> {

--- a/dongle/services/wallet/wallet.service.ts
+++ b/dongle/services/wallet/wallet.service.ts
@@ -7,7 +7,23 @@ import {
   signTransaction,
 } from "@stellar/freighter-api";
 
+function isFreighterMissingError(message: string | undefined): boolean {
+  if (!message) return false;
+  const lower = message.toLowerCase();
+  return lower.includes("not installed") || lower.includes("not found");
+}
+
 export const walletService = {
+  /** Returns false when the Freighter extension is not available in the browser. */
+  async isFreighterAvailable(): Promise<boolean> {
+    try {
+      const { error } = await freighterIsConnected();
+      return !isFreighterMissingError(error?.message);
+    } catch {
+      return false;
+    }
+  },
+
   // Opens Freighter popup and returns the user's public key on approval
   async connectWallet(): Promise<string> {
     const { isConnected, error: connErr } = await freighterIsConnected();


### PR DESCRIPTION
## Summary
- Add reusable WalletStatePanel component and useWalletPageGate hook
- Apply consistent wallet states (disconnected, connecting, wrong network, Freighter missing, unfunded) to Profile, Admin, Reviews, and Submit Project pages
- Include Friendbot guidance for unfunded testnet accounts

Closes #117

## Test plan
- [x] npm run lint
- [x] npm run typecheck
- [x] npm test
- [x] npm run build

Made with [Cursor](https://cursor.com)