### PR TITLE
[112] Add transaction progress states beyond a single toast

### DIFF
--- a/dongle/__tests__/components/TransactionProgressPanel.test.tsx
+++ b/dongle/__tests__/components/TransactionProgressPanel.test.tsx
@@ -1,0 +1,30 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import TransactionProgressPanel from "@/components/transactions/TransactionProgressPanel";
+import { createProgressState } from "@/lib/transaction-progress";
+
+describe("TransactionProgressPanel", () => {
+  it("renders signing phase guidance", () => {
+    render(
+      <TransactionProgressPanel progress={createProgressState("signing")} />,
+    );
+
+    expect(screen.getByText("Approve in Freighter")).toBeInTheDocument();
+    expect(screen.getByText(/Freighter extension/i)).toBeInTheDocument();
+  });
+
+  it("shows retry action for retryable failures", () => {
+    const onRetry = vi.fn();
+    render(
+      <TransactionProgressPanel
+        progress={createProgressState("failure", {
+          error: new Error("Network timeout"),
+        })}
+        onRetry={onRetry}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /Retry transaction/i }));
+    expect(onRetry).toHaveBeenCalled();
+  });
+});

--- a/dongle/__tests__/lib/transaction-progress.test.ts
+++ b/dongle/__tests__/lib/transaction-progress.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from "vitest";
+import {
+  createProgressState,
+  getTransactionPhaseMessage,
+  isTransactionPhaseRetryable,
+  isUserRejectionError,
+} from "@/lib/transaction-progress";
+
+describe("transaction-progress", () => {
+  it("describes signing vs confirming phases distinctly", () => {
+    expect(getTransactionPhaseMessage("signing")).toContain("Freighter");
+    expect(getTransactionPhaseMessage("confirming", { txHash: "ABCDEF123456" })).toContain(
+      "confirmation",
+    );
+  });
+
+  it("marks user rejections as non-retryable by default", () => {
+    const error = new Error("User rejected the request");
+    expect(isUserRejectionError(error)).toBe(true);
+    expect(isTransactionPhaseRetryable(error)).toBe(false);
+    expect(createProgressState("failure", { error }).retryable).toBe(false);
+  });
+
+  it("allows retry guidance for network failures", () => {
+    const error = new Error("Timeout waiting for transaction");
+    expect(createProgressState("failure", { error }).retryable).toBe(true);
+    expect(getTransactionPhaseMessage("failure", { error })).toContain("retry");
+  });
+});

--- a/dongle/app/projects/[id]/edit/page.tsx
+++ b/dongle/app/projects/[id]/edit/page.tsx
@@ -1,20 +1,19 @@
-\"use client\";
+"use client";
 
-import React, { useState, useEffect } from \"react\";
-import { useParams, useRouter } from \"next/navigation\";
-import ProjectForm from \"@/components/projects/ProjectForm\";
-import { sorobanService, ProjectData } from \"@/services/stellar/soroban.service\";
-import { toast } from \"sonner\";
-import { AlertTriangle, ArrowLeft } from \"lucide-react\";
-import { Button } from \"@/components/ui/Button\";
-import { Card } from \"@/components/ui/Card\";
+import React, { useState, useEffect } from "react";
+import { useParams, useRouter } from "next/navigation";
+import ProjectForm from "@/components/projects/ProjectForm";
+import { sorobanService, ProjectData } from "@/services/stellar/soroban.service";
+import { AlertTriangle, ArrowLeft } from "lucide-react";
+import { Button } from "@/components/ui/Button";
+import { Card } from "@/components/ui/Card";
 import WalletStatePanel, {
   WalletStateLoadingPanel,
-} from \"@/components/wallet/WalletStatePanel\";
-import { useWalletPageGate } from \"@/hooks/useWalletPageGate\";
+} from "@/components/wallet/WalletStatePanel";
+import { useWalletPageGate } from "@/hooks/useWalletPageGate";
 
 const EDIT_PURPOSE =
-  \"Connect Freighter to edit and update your project on-chain.\";
+  "Connect Freighter to edit and update your project on-chain.";
 
 export default function EditProjectPage() {
   const params = useParams();
@@ -59,30 +58,16 @@ export default function EditProjectPage() {
     };
   }, [projectId, gate.state]);
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const handleUpdate = async (data: any) => {
-    if (!project) return;
-    const promise = sorobanService.updateProject(projectId, data);
-    toast.promise(promise, {
-      loading: \"Updating your project on-chain...\",
-      success: (res) => {
-        setTimeout(() => router.push(`/projects/${projectId}`), 2000);
-        return `Project updated successfully! Tx: ${res.hash.substring(0, 8)}...`;
-      },
-      error: (err) => `Update failed: ${err.message}`,
-    });
-  };
-
-  const pageClass = \"min-h-screen pt-8 pb-24 bg-zinc-50 dark:bg-zinc-950\";
+  const pageClass = "min-h-screen pt-8 pb-24 bg-zinc-50 dark:bg-zinc-950";
 
   // Wallet gate — show before attempting any project fetch
-  if (gate.state !== \"ready\") {
+  if (gate.state !== "ready") {
     return (
       <main className={pageClass}>
-        <div className=\"container mx-auto px-4\">
-          <div className=\"max-w-xl mx-auto animate-fade-in\">
-            {gate.state === \"account-loading\" ? (
-              <WalletStateLoadingPanel message=\"Verifying your wallet...\" />
+        <div className="container mx-auto px-4">
+          <div className="max-w-xl mx-auto animate-fade-in">
+            {gate.state === "account-loading" ? (
+              <WalletStateLoadingPanel message="Verifying your wallet..." />
             ) : (
               <WalletStatePanel
                 state={gate.state}
@@ -102,13 +87,13 @@ export default function EditProjectPage() {
   if (loading) {
     return (
       <main className={pageClass}>
-        <div className=\"container mx-auto px-4\">
-          <div className=\"max-w-2xl mx-auto animate-pulse space-y-4\">
-            <div className=\"h-8 bg-zinc-200 dark:bg-zinc-800 rounded\" />
-            <div className=\"h-4 bg-zinc-200 dark:bg-zinc-800 rounded w-2/3\" />
-            <div className=\"h-12 bg-zinc-200 dark:bg-zinc-800 rounded\" />
-            <div className=\"h-12 bg-zinc-200 dark:bg-zinc-800 rounded\" />
-            <div className=\"h-24 bg-zinc-200 dark:bg-zinc-800 rounded\" />
+        <div className="container mx-auto px-4">
+          <div className="max-w-2xl mx-auto animate-pulse space-y-4">
+            <div className="h-8 bg-zinc-200 dark:bg-zinc-800 rounded" />
+            <div className="h-4 bg-zinc-200 dark:bg-zinc-800 rounded w-2/3" />
+            <div className="h-12 bg-zinc-200 dark:bg-zinc-800 rounded" />
+            <div className="h-12 bg-zinc-200 dark:bg-zinc-800 rounded" />
+            <div className="h-24 bg-zinc-200 dark:bg-zinc-800 rounded" />
           </div>
         </div>
       </main>
@@ -118,15 +103,15 @@ export default function EditProjectPage() {
   if (error || !project) {
     return (
       <main className={pageClass}>
-        <div className=\"container mx-auto px-4\">
-          <Card className=\"max-w-2xl mx-auto p-8 text-center\">
-            <AlertTriangle className=\"w-12 h-12 text-red-500 mx-auto mb-4\" />
-            <h2 className=\"text-2xl font-bold mb-2\">{error ? \"Error\" : \"Project Not Found\"}</h2>
-            <p className=\"text-zinc-600 dark:text-zinc-400 mb-6\">
-              {error ?? \"The project you're trying to edit doesn't exist.\"}
+        <div className="container mx-auto px-4">
+          <Card className="max-w-2xl mx-auto p-8 text-center">
+            <AlertTriangle className="w-12 h-12 text-red-500 mx-auto mb-4" />
+            <h2 className="text-2xl font-bold mb-2">{error ? "Error" : "Project Not Found"}</h2>
+            <p className="text-zinc-600 dark:text-zinc-400 mb-6">
+              {error ?? "The project you're trying to edit doesn't exist."}
             </p>
             <Button onClick={() => router.back()}>
-              <ArrowLeft className=\"w-4 h-4 mr-2\" />
+              <ArrowLeft className="w-4 h-4 mr-2" />
               Go Back
             </Button>
           </Card>
@@ -138,15 +123,15 @@ export default function EditProjectPage() {
   if (gate.publicKey && project.owner !== gate.publicKey) {
     return (
       <main className={pageClass}>
-        <div className=\"container mx-auto px-4\">
-          <Card className=\"max-w-2xl mx-auto p-8 text-center\">
-            <AlertTriangle className=\"w-12 h-12 text-red-500 mx-auto mb-4\" />
-            <h2 className=\"text-2xl font-bold mb-2\">Access Denied</h2>
-            <p className=\"text-zinc-600 dark:text-zinc-400 mb-6\">
+        <div className="container mx-auto px-4">
+          <Card className="max-w-2xl mx-auto p-8 text-center">
+            <AlertTriangle className="w-12 h-12 text-red-500 mx-auto mb-4" />
+            <h2 className="text-2xl font-bold mb-2">Access Denied</h2>
+            <p className="text-zinc-600 dark:text-zinc-400 mb-6">
               Only the project owner can edit this project.
             </p>
             <Button onClick={() => router.back()}>
-              <ArrowLeft className=\"w-4 h-4 mr-2\" />
+              <ArrowLeft className="w-4 h-4 mr-2" />
               Go Back
             </Button>
           </Card>
@@ -157,9 +142,10 @@ export default function EditProjectPage() {
 
   return (
     <main className={pageClass}>
-      <div className=\"container mx-auto px-4\">
+      <div className="container mx-auto px-4">
         <ProjectForm
-          mode=\"edit\"
+          mode="edit"
+          projectId={projectId}
           initialData={{
             name: project.name,
             category: project.category,
@@ -169,8 +155,6 @@ export default function EditProjectPage() {
             logoUrl: project.logoUrl,
             docsUrl: project.docsUrl,
           }}
-          projectId={projectId}
-          onSubmit={handleUpdate}
         />
       </div>
     </main>

--- a/dongle/components/projects/ProjectForm.tsx
+++ b/dongle/components/projects/ProjectForm.tsx
@@ -8,9 +8,10 @@ import { FormField } from "@/components/ui/FormField";
 import { SelectField } from "@/components/ui/SelectField";
 import { TextAreaField } from "@/components/ui/TextAreaField";
 import { sorobanService } from "@/services/stellar/soroban.service";
-import { toast } from "sonner";
 import { Rocket, CheckCircle2 } from "lucide-react";
 import { useRouter } from "next/navigation";
+import TransactionProgressPanel from "@/components/transactions/TransactionProgressPanel";
+import { useOnChainTransaction } from "@/hooks/useOnChainTransaction";
 
 import { Button } from "@/components/ui/Button";
 import { Card } from "@/components/ui/Card";
@@ -69,10 +70,12 @@ type ProjectFormProps = {
 export default function ProjectForm({
   mode = "create",
   initialData,
+  projectId,
   onSubmit: customOnSubmit,
-}: Omit<ProjectFormProps, "projectId"> & { projectId?: string } = {}) {
+}: ProjectFormProps = {}) {
   const [isSubmitting, setIsSubmitting] = useState(false);
   const router = useRouter();
+  const { progress, run, retry, isInProgress } = useOnChainTransaction();
 
   const isMountedRef = React.useRef(true);
   const redirectTimerRef = React.useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -118,25 +121,22 @@ export default function ProjectForm({
     }
 
     setIsSubmitting(true);
-    const promise = sorobanService.registerProject(payload);
-
-    toast.promise(promise, {
-      loading: "Registering your project on-chain...",
-      success: (res) => {
-        if (isMountedRef.current) {
-          setIsSubmitting(false);
-          reset();
-        }
-        redirectTimerRef.current = setTimeout(() => router.push("/"), 2000);
-        return `Project registered successfully! Tx: ${res.hash.substring(0, 8)}...`;
-      },
-      error: (err) => {
-        if (isMountedRef.current) {
-          setIsSubmitting(false);
-        }
-        return `Registration failed: ${err.message}`;
-      },
+    const result = await run((onPhaseChange) => {
+      if (mode === "edit" && projectId) {
+        return sorobanService.updateProject(projectId, payload, { onPhaseChange });
+      }
+      return sorobanService.registerProject(payload, { onPhaseChange });
     });
+    if (isMountedRef.current) {
+      setIsSubmitting(false);
+    }
+
+    if (result && isMountedRef.current) {
+      reset();
+      const redirectPath =
+        mode === "edit" && projectId ? `/projects/${projectId}` : "/";
+      redirectTimerRef.current = setTimeout(() => router.push(redirectPath), 1500);
+    }
   };
 
   return (
@@ -214,17 +214,27 @@ export default function ProjectForm({
 
         <Button
           type="submit"
-          isLoading={isSubmitting}
+          isLoading={isSubmitting || isInProgress}
           className="w-full"
           size="lg"
           rightIcon={<CheckCircle2 className="w-5 h-5" />}
         >
-          {isSubmitting
+          {isSubmitting || isInProgress
             ? "Processing Transaction..."
             : mode === "edit"
             ? "Update Project"
             : "Submit Registration"}
         </Button>
+
+        {progress.phase !== "idle" && (
+          <TransactionProgressPanel
+            progress={progress}
+            onRetry={() => {
+              setIsSubmitting(true);
+              void retry().finally(() => setIsSubmitting(false));
+            }}
+          />
+        )}
 
         <p className="text-center text-xs text-zinc-400 dark:text-zinc-500 px-8">
           {mode === "edit"

--- a/dongle/components/transactions/TransactionProgressPanel.tsx
+++ b/dongle/components/transactions/TransactionProgressPanel.tsx
@@ -1,0 +1,122 @@
+"use client";
+
+import React from "react";
+import {
+  AlertCircle,
+  CheckCircle2,
+  Circle,
+  Loader2,
+  RefreshCw,
+} from "lucide-react";
+import { Button } from "@/components/ui/Button";
+import {
+  TRANSACTION_PHASE_LABELS,
+  TRANSACTION_PHASE_ORDER,
+  type TransactionProgressState,
+} from "@/lib/transaction-progress";
+
+interface TransactionProgressPanelProps {
+  progress: TransactionProgressState;
+  onRetry?: () => void;
+  className?: string;
+}
+
+function StepIcon({
+  completed,
+  active,
+  failed,
+}: {
+  completed: boolean;
+  active: boolean;
+  failed: boolean;
+}) {
+  if (failed) {
+    return <AlertCircle className="w-5 h-5 text-red-500" aria-hidden="true" />;
+  }
+  if (completed) {
+    return <CheckCircle2 className="w-5 h-5 text-green-500" aria-hidden="true" />;
+  }
+  if (active) {
+    return <Loader2 className="w-5 h-5 text-blue-500 animate-spin" aria-hidden="true" />;
+  }
+  return <Circle className="w-5 h-5 text-zinc-300 dark:text-zinc-700" aria-hidden="true" />;
+}
+
+export default function TransactionProgressPanel({
+  progress,
+  onRetry,
+  className = "",
+}: TransactionProgressPanelProps) {
+  const { phase, message, errorMessage, retryable } = progress;
+  const isActive = phase !== "idle" && phase !== "success" && phase !== "failure";
+  const activeIndex = TRANSACTION_PHASE_ORDER.indexOf(
+    phase === "failure" || phase === "idle" ? "preparing" : phase,
+  );
+
+  if (phase === "idle") {
+    return null;
+  }
+
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      className={`rounded-2xl border border-zinc-200 dark:border-zinc-800 bg-zinc-50 dark:bg-zinc-900/60 p-5 ${className}`}
+    >
+      <p className="font-semibold text-zinc-900 dark:text-zinc-100 mb-1">
+        {phase === "failure"
+          ? "Transaction failed"
+          : phase === "success"
+            ? "Transaction complete"
+            : "Transaction in progress"}
+      </p>
+      <p className="text-sm text-zinc-600 dark:text-zinc-400 mb-4">{message}</p>
+
+      <ol className="space-y-3">
+        {(TRANSACTION_PHASE_ORDER.slice(0, -1) as Array<
+          keyof typeof TRANSACTION_PHASE_LABELS
+        >).map((step, index) => {
+          const completed =
+            phase === "success" || (isActive && index < activeIndex);
+          const active = isActive && index === activeIndex;
+          const failed = phase === "failure" && index === activeIndex;
+          const label = TRANSACTION_PHASE_LABELS[step];
+
+          return (
+            <li key={step} className="flex items-center gap-3 text-sm">
+              <StepIcon completed={completed} active={active} failed={failed} />
+              <span
+                className={
+                  completed
+                    ? "text-zinc-700 dark:text-zinc-300"
+                    : active
+                      ? "font-medium text-zinc-900 dark:text-zinc-100"
+                      : "text-zinc-400 dark:text-zinc-500"
+                }
+              >
+                {label}
+              </span>
+            </li>
+          );
+        })}
+      </ol>
+
+      {phase === "failure" && errorMessage && (
+        <p className="mt-4 text-sm text-red-600 dark:text-red-400">{errorMessage}</p>
+      )}
+
+      {phase === "failure" && retryable && onRetry && (
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          className="mt-4 inline-flex items-center gap-2"
+          onClick={onRetry}
+        >
+          <RefreshCw className="w-4 h-4" />
+          Retry transaction
+        </Button>
+      )}
+    </div>
+  );
+}

--- a/dongle/hooks/useOnChainTransaction.ts
+++ b/dongle/hooks/useOnChainTransaction.ts
@@ -1,0 +1,83 @@
+"use client";
+
+import { useCallback, useRef, useState } from "react";
+import { toast } from "sonner";
+import {
+  createProgressState,
+  type TransactionPhase,
+  type TransactionProgressState,
+} from "@/lib/transaction-progress";
+
+const IDLE_STATE = createProgressState("idle");
+
+export function useOnChainTransaction() {
+  const [progress, setProgress] = useState<TransactionProgressState>(IDLE_STATE);
+  const lastActionRef = useRef<(() => Promise<unknown>) | null>(null);
+
+  const handlePhaseChange = useCallback(
+    (phase: TransactionPhase, meta?: { txHash?: string; error?: Error }) => {
+      setProgress(createProgressState(phase, meta));
+
+      if (phase === "signing") {
+        toast.message("Approve in Freighter", {
+          description: "Your wallet extension should prompt you to sign.",
+        });
+      } else if (phase === "confirming") {
+        toast.message("Submitted to network", {
+          description: "Waiting for Stellar confirmation. You can keep this page open.",
+        });
+      } else if (phase === "success") {
+        toast.success("Transaction confirmed on-chain");
+      } else if (phase === "failure") {
+        toast.error(meta?.error?.message ?? "Transaction failed");
+      }
+    },
+    [],
+  );
+
+  const run = useCallback(
+    async <T,>(
+      action: (onPhaseChange: typeof handlePhaseChange) => Promise<T>,
+    ): Promise<T | null> => {
+      const wrapped = () => action(handlePhaseChange);
+      lastActionRef.current = wrapped;
+
+      try {
+        const result = await wrapped();
+        return result;
+      } catch (error) {
+        const err = error instanceof Error ? error : new Error(String(error));
+        handlePhaseChange("failure", { error: err });
+        return null;
+      }
+    },
+    [handlePhaseChange],
+  );
+
+  const reset = useCallback(() => {
+    setProgress(IDLE_STATE);
+  }, []);
+
+  const retry = useCallback(async () => {
+    if (!lastActionRef.current) return null;
+    reset();
+    try {
+      return await lastActionRef.current();
+    } catch (error) {
+      const err = error instanceof Error ? error : new Error(String(error));
+      handlePhaseChange("failure", { error: err });
+      return null;
+    }
+  }, [handlePhaseChange, reset]);
+
+  return {
+    progress,
+    run,
+    reset,
+    retry,
+    isInProgress:
+      progress.phase !== "idle" &&
+      progress.phase !== "success" &&
+      progress.phase !== "failure",
+  };
+}

--- a/dongle/lib/transaction-progress.ts
+++ b/dongle/lib/transaction-progress.ts
@@ -1,0 +1,112 @@
+export type TransactionPhase =
+  | "idle"
+  | "preparing"
+  | "signing"
+  | "submitting"
+  | "confirming"
+  | "success"
+  | "failure";
+
+export interface TransactionPhaseMeta {
+  txHash?: string;
+  error?: Error;
+}
+
+export interface TransactionProgressState {
+  phase: TransactionPhase;
+  message: string;
+  txHash?: string;
+  errorMessage?: string;
+  retryable: boolean;
+}
+
+export type ProgressStep = Exclude<TransactionPhase, "idle" | "failure">;
+
+export const TRANSACTION_PHASE_ORDER: ProgressStep[] = [
+  "preparing",
+  "signing",
+  "submitting",
+  "confirming",
+  "success",
+];
+
+export const TRANSACTION_PHASE_LABELS: Record<ProgressStep, string> = {
+  preparing: "Preparing transaction",
+  signing: "Approve in Freighter",
+  submitting: "Submitting to network",
+  confirming: "Waiting for confirmation",
+  success: "Confirmed on-chain",
+};
+
+export function getTransactionPhaseMessage(
+  phase: TransactionPhase,
+  meta: TransactionPhaseMeta = {},
+): string {
+  switch (phase) {
+    case "preparing":
+      return "Building and simulating your Soroban transaction...";
+    case "signing":
+      return "Check your Freighter extension and approve the signature request.";
+    case "submitting":
+      return "Broadcasting the signed transaction to Stellar...";
+    case "confirming":
+      return meta.txHash
+        ? `Waiting for network confirmation (${meta.txHash.slice(0, 8)}...).`
+        : "Waiting for network confirmation. This can take up to a minute.";
+    case "success":
+      return meta.txHash
+        ? `Transaction confirmed: ${meta.txHash.slice(0, 8)}...`
+        : "Transaction confirmed on-chain.";
+    case "failure": {
+      const base = meta.error?.message ?? "Transaction failed.";
+      if (isUserRejectionError(meta.error)) {
+        return `${base} You can edit your details and try again when ready.`;
+      }
+      if (isNetworkMismatchError(meta.error)) {
+        return `${base} Switch Freighter to the expected network, then retry.`;
+      }
+      return `${base} Review the details below and retry when ready.`;
+    }
+    default:
+      return "";
+  }
+}
+
+export function isUserRejectionError(error?: Error): boolean {
+  if (!error) return false;
+  const msg = error.message.toLowerCase();
+  return (
+    msg.includes("user rejected") ||
+    msg.includes("user declined") ||
+    msg.includes("cancelled") ||
+    msg.includes("canceled")
+  );
+}
+
+export function isNetworkMismatchError(error?: Error): boolean {
+  if (!error) return false;
+  return error.name === "NetworkMismatchError" || error.message.includes("Wrong network");
+}
+
+export function isTransactionPhaseRetryable(error?: Error): boolean {
+  if (!error) return true;
+  return !isUserRejectionError(error);
+}
+
+export function createProgressState(
+  phase: TransactionPhase,
+  meta: TransactionPhaseMeta = {},
+): TransactionProgressState {
+  return {
+    phase,
+    message: getTransactionPhaseMessage(phase, meta),
+    txHash: meta.txHash,
+    errorMessage: meta.error?.message,
+    retryable: phase === "failure" ? isTransactionPhaseRetryable(meta.error) : false,
+  };
+}
+
+export function getPhaseIndex(phase: TransactionPhase): number {
+  if (phase === "idle" || phase === "failure") return -1;
+  return TRANSACTION_PHASE_ORDER.indexOf(phase);
+}

--- a/dongle/services/stellar/soroban.service.ts
+++ b/dongle/services/stellar/soroban.service.ts
@@ -14,10 +14,23 @@ import {
   getNetworkLabel,
 } from "@/context/wallet.context";
 import { generateId } from "@/lib/id-generator";
+import type { TransactionPhase } from "@/lib/transaction-progress";
 
 const server = new rpc.Server(SOROBAN_CONFIG.RPC_URL, {
   timeout: 15000,
 });
+
+export type TransactionPhaseHandler = (
+  phase: TransactionPhase,
+  meta?: { txHash?: string; error?: Error },
+) => void;
+
+export interface SorobanTransactionOptions {
+  onPhaseChange?: TransactionPhaseHandler;
+  signal?: AbortSignal;
+  timeoutMs?: number;
+  intervalMs?: number;
+}
 
 // ─── Network mismatch error ──────────────────────────────────────────────────
 
@@ -104,10 +117,17 @@ async function pollTransaction(
   {
     timeoutMs = DEFAULT_POLL_TIMEOUT_MS,
     intervalMs = DEFAULT_POLL_INTERVAL_MS,
+    onPhaseChange,
     signal,
-  }: { timeoutMs?: number; intervalMs?: number; signal?: AbortSignal } = {},
+  }: {
+    timeoutMs?: number;
+    intervalMs?: number;
+    onPhaseChange?: TransactionPhaseHandler;
+    signal?: AbortSignal;
+  } = {},
 ) {
   const startedAt = Date.now();
+  onPhaseChange?.("confirming", { txHash: hash });
 
   if (signal?.aborted) {
     throw new Error("Transaction polling aborted");
@@ -134,7 +154,59 @@ async function pollTransaction(
     );
   }
 
+  onPhaseChange?.("success", { txHash: hash });
   return last;
+}
+
+async function executeContractTransaction(
+  publicKey: string,
+  buildOperation: (contract: Contract) => ReturnType<Contract["call"]>,
+  options: SorobanTransactionOptions = {},
+) {
+  const { onPhaseChange, signal, timeoutMs, intervalMs } = options;
+
+  onPhaseChange?.("preparing");
+  await assertCorrectNetwork();
+
+  const account = await server.getAccount(publicKey);
+  const source = new Account(publicKey, account.sequenceNumber());
+  const contract = new Contract(DONGLE_CONTRACTS.PROJECT_REGISTRY);
+
+  const unsignedTx = new TransactionBuilder(source, {
+    fee: BASE_FEE,
+    networkPassphrase: SOROBAN_CONFIG.NETWORK_PASSPHRASE,
+  })
+    .addOperation(buildOperation(contract))
+    .setTimeout(30)
+    .build();
+
+  const preparedTx = await server.prepareTransaction(unsignedTx);
+
+  onPhaseChange?.("signing");
+  const signedXdr = await walletService.signTransaction(
+    preparedTx.toXDR(),
+    SOROBAN_CONFIG.NETWORK_PASSPHRASE,
+  );
+
+  onPhaseChange?.("submitting");
+  const sendResponse = await server.sendTransaction(
+    TransactionBuilder.fromXDR(signedXdr, SOROBAN_CONFIG.NETWORK_PASSPHRASE),
+  );
+
+  if (sendResponse.status === "ERROR") {
+    throw new Error(
+      "Transaction failed: " + JSON.stringify(sendResponse.errorResult),
+    );
+  }
+
+  await pollTransaction(sendResponse.hash, {
+    onPhaseChange,
+    signal,
+    timeoutMs,
+    intervalMs,
+  });
+
+  return { hash: sendResponse.hash, status: "SUCCESS" as const };
 }
 
 export const sorobanService = {
@@ -143,7 +215,7 @@ export const sorobanService = {
    */
   async registerProject(
     params: ProjectRegistrationParams,
-    options?: { signal?: AbortSignal; timeoutMs?: number; intervalMs?: number },
+    options: SorobanTransactionOptions = {},
   ) {
     let publicKey: string;
     try {
@@ -152,20 +224,21 @@ export const sorobanService = {
       console.warn(
         "[SorobanService] No wallet connected, using mock registration",
       );
-      await new Promise((resolve) => setTimeout(resolve, 2000));
+      options.onPhaseChange?.("preparing");
+      await new Promise((resolve) => setTimeout(resolve, 500));
+      options.onPhaseChange?.("signing");
+      await new Promise((resolve) => setTimeout(resolve, 500));
+      options.onPhaseChange?.("submitting");
+      await new Promise((resolve) => setTimeout(resolve, 500));
+      const hash = "mock_hash_" + generateId();
+      options.onPhaseChange?.("confirming", { txHash: hash });
+      await new Promise((resolve) => setTimeout(resolve, 500));
+      options.onPhaseChange?.("success", { txHash: hash });
       return {
-        hash: "mock_hash_" + generateId(),
+        hash,
         status: "SUCCESS",
       };
     }
-
-    // Validate network before building or signing any transaction
-    await assertCorrectNetwork();
-
-    const account = await server.getAccount(publicKey);
-    const source = new Account(publicKey, account.sequenceNumber());
-
-    const contract = new Contract(DONGLE_CONTRACTS.PROJECT_REGISTRY);
 
     const args = [
       nativeToScVal(params.name),
@@ -177,47 +250,14 @@ export const sorobanService = {
       nativeToScVal(params.docsUrl),
     ];
 
-    const unsignedTx = new TransactionBuilder(source, {
-      fee: BASE_FEE,
-      networkPassphrase: SOROBAN_CONFIG.NETWORK_PASSPHRASE,
-    })
-      .addOperation(contract.call("register_project", ...args))
-      .setTimeout(30)
-      .build();
-
-    // Soroban-specific: prepare ensures footprint/resources are set correctly.
-    const preparedTx = await server.prepareTransaction(unsignedTx);
-
-    const signedXdr = await walletService.signTransaction(
-      preparedTx.toXDR(),
-      SOROBAN_CONFIG.NETWORK_PASSPHRASE,
+    const result = await executeContractTransaction(
+      publicKey,
+      (contract) => contract.call("register_project", ...args),
+      options,
     );
 
-    const sendResponse = await server.sendTransaction(
-      TransactionBuilder.fromXDR(
-        signedXdr,
-        SOROBAN_CONFIG.NETWORK_PASSPHRASE,
-      ),
-    );
-
-    if (sendResponse.status === "ERROR") {
-      throw new Error(
-        "Transaction failed: " + JSON.stringify(sendResponse.errorResult),
-      );
-    }
-
-    await pollTransaction(sendResponse.hash, {
-      signal: options?.signal,
-      timeoutMs: options?.timeoutMs,
-      intervalMs: options?.intervalMs,
-    });
-
-    console.log(
-      "[SorobanService] Registration successful:",
-      sendResponse.hash,
-    );
-
-    return { hash: sendResponse.hash, status: "SUCCESS" };
+    console.log("[SorobanService] Registration successful:", result.hash);
+    return result;
   },
 
   /**
@@ -322,7 +362,7 @@ export const sorobanService = {
   async updateProject(
     projectId: string,
     params: ProjectRegistrationParams,
-    options?: { signal?: AbortSignal; timeoutMs?: number; intervalMs?: number },
+    options: SorobanTransactionOptions = {},
   ) {
     let publicKey: string;
     try {
@@ -331,9 +371,12 @@ export const sorobanService = {
       console.warn(
         "[SorobanService] No wallet connected, using mock update",
       );
-      await new Promise((resolve) => setTimeout(resolve, 2000));
+      options.onPhaseChange?.("preparing");
+      await new Promise((resolve) => setTimeout(resolve, 500));
+      const hash = "mock_update_hash_" + generateId();
+      options.onPhaseChange?.("success", { txHash: hash });
       return {
-        hash: "mock_update_hash_" + generateId(),
+        hash,
         status: "SUCCESS",
       };
     }
@@ -343,14 +386,6 @@ export const sorobanService = {
     if (project.owner !== publicKey) {
       throw new Error("Only project owner can update the project");
     }
-
-    // Validate network before building or signing any transaction
-    await assertCorrectNetwork();
-
-    const account = await server.getAccount(publicKey);
-    const source = new Account(publicKey, account.sequenceNumber());
-
-    const contract = new Contract(DONGLE_CONTRACTS.PROJECT_REGISTRY);
 
     const args = [
       nativeToScVal(projectId),
@@ -363,46 +398,14 @@ export const sorobanService = {
       nativeToScVal(params.docsUrl),
     ];
 
-    const unsignedTx = new TransactionBuilder(source, {
-      fee: BASE_FEE,
-      networkPassphrase: SOROBAN_CONFIG.NETWORK_PASSPHRASE,
-    })
-      .addOperation(contract.call("update_project", ...args))
-      .setTimeout(30)
-      .build();
-
-    const preparedTx = await server.prepareTransaction(unsignedTx);
-
-    const signedXdr = await walletService.signTransaction(
-      preparedTx.toXDR(),
-      SOROBAN_CONFIG.NETWORK_PASSPHRASE,
+    const result = await executeContractTransaction(
+      publicKey,
+      (contract) => contract.call("update_project", ...args),
+      options,
     );
 
-    const sendResponse = await server.sendTransaction(
-      TransactionBuilder.fromXDR(
-        signedXdr,
-        SOROBAN_CONFIG.NETWORK_PASSPHRASE,
-      ),
-    );
-
-    if (sendResponse.status === "ERROR") {
-      throw new Error(
-        "Transaction failed: " + JSON.stringify(sendResponse.errorResult),
-      );
-    }
-
-    await pollTransaction(sendResponse.hash, {
-      signal: options?.signal,
-      timeoutMs: options?.timeoutMs,
-      intervalMs: options?.intervalMs,
-    });
-
-    console.log(
-      "[SorobanService] Update successful:",
-      sendResponse.hash,
-    );
-
-    return { hash: sendResponse.hash, status: "SUCCESS" };
+    console.log("[SorobanService] Update successful:", result.hash);
+    return result;
   },
 
   getServer() {


### PR DESCRIPTION
## Summary
- Add transaction phase tracking (preparing, signing, submitting, confirming, success, failure) to the Soroban service
- Introduce `useOnChainTransaction` hook and `TransactionProgressPanel` for non-blocking progress UI
- Wire project registration and update flows to show wallet approval vs network confirmation

Closes #112