### PR TITLE
feat: Add project audit and security document links

### DIFF
--- a/dongle/app/projects/[id]/page.tsx
+++ b/dongle/app/projects/[id]/page.tsx
@@ -30,6 +30,8 @@ import {
   Calendar,
   AlertCircle,
   Info,
+  Shield,
+  Bug,
 } from "lucide-react";
 import { toast } from "sonner";
 import { ReportProjectModal } from "@/components/projects/ReportProjectModal";
@@ -348,6 +350,34 @@ export default function ProjectDetailPage() {
                       <Button variant="outline" size="sm">
                         <GitBranch className="w-4 h-4 mr-2" />
                         GitHub
+                        <ExternalLink className="w-3 h-3 ml-1" />
+                      </Button>
+                    </a>
+                  )}
+                  {project.auditReportUrl && (
+                    <a
+                      href={project.auditReportUrl}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      onClick={(e) => handleExternalLinkClick(e, project.auditReportUrl!)}
+                    >
+                      <Button variant="outline" size="sm" className="text-green-600 border-green-200 hover:bg-green-50 dark:hover:bg-green-900/20">
+                        <Shield className="w-4 h-4 mr-2" />
+                        Audit Report
+                        <ExternalLink className="w-3 h-3 ml-1" />
+                      </Button>
+                    </a>
+                  )}
+                  {project.bugBountyUrl && (
+                    <a
+                      href={project.bugBountyUrl}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      onClick={(e) => handleExternalLinkClick(e, project.bugBountyUrl!)}
+                    >
+                      <Button variant="outline" size="sm" className="text-amber-600 border-amber-200 hover:bg-amber-50 dark:hover:bg-amber-900/20">
+                        <Bug className="w-4 h-4 mr-2" />
+                        Bug Bounty
                         <ExternalLink className="w-3 h-3 ml-1" />
                       </Button>
                     </a>

--- a/dongle/components/projects/ProjectForm.tsx
+++ b/dongle/components/projects/ProjectForm.tsx
@@ -60,6 +60,8 @@ const projectSchema = z.object({
   githubUrl: optionalUrlSchema,
   logoUrl: optionalUrlSchema,
   docsUrl: optionalUrlSchema,
+  auditReportUrl: optionalUrlSchema,
+  bugBountyUrl: optionalUrlSchema,
 });
 
 type ProjectFormValues = z.infer<typeof projectSchema>;
@@ -104,6 +106,8 @@ export default function ProjectForm({
       githubUrl: initialData?.githubUrl || "",
       logoUrl: initialData?.logoUrl || "",
       docsUrl: initialData?.docsUrl || "",
+      auditReportUrl: initialData?.auditReportUrl || "",
+      bugBountyUrl: initialData?.bugBountyUrl || "",
     },
   });
 
@@ -274,6 +278,21 @@ export default function ProjectForm({
             placeholder="https://docs..."
             {...register("docsUrl")}
             error={errors.docsUrl?.message}
+          />
+        </div>
+
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+          <FormField
+            label="Audit Report URL (Optional)"
+            placeholder="https://..."
+            {...register("auditReportUrl")}
+            error={errors.auditReportUrl?.message}
+          />
+          <FormField
+            label="Bug Bounty URL (Optional)"
+            placeholder="https://..."
+            {...register("bugBountyUrl")}
+            error={errors.bugBountyUrl?.message}
           />
         </div>
 

--- a/dongle/types/project.ts
+++ b/dongle/types/project.ts
@@ -79,6 +79,8 @@ export interface Project {
   githubUrl?: string;
   logoUrl?: string;
   docsUrl?: string;
+  auditReportUrl?: string;
+  bugBountyUrl?: string;
   domain?: string;
   ownerAddress?: string;
 }


### PR DESCRIPTION
Fixes #137. Added auditReportUrl and bugBountyUrl to the Project model, updated the submission form to capture them, and the detail pages to display them as external links.