### PR TITLE
feat(projects): extend submission checklist per #249

### DIFF
--- a/dongle/__tests__/components/SubmissionChecklist.test.tsx
+++ b/dongle/__tests__/components/SubmissionChecklist.test.tsx
@@ -1,0 +1,89 @@
+﻿import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { SubmissionChecklist } from "@/components/projects/SubmissionChecklist";
+
+describe("SubmissionChecklist", () => {
+  it("renders the checklist near the submit/edit flow with all named topics", () => {
+    render(<SubmissionChecklist formData={{}} />);
+
+    // Covers the topics named in #249: website, docs, logo, repository,
+    // audit links, and verification request (contract IDs is covered in
+    // the verification guidance panel, not as a separate form field).
+    expect(screen.getByText("Project Website")).toBeInTheDocument();
+    expect(screen.getByText("Documentation")).toBeInTheDocument();
+    expect(screen.getByText("Logo URL")).toBeInTheDocument();
+    expect(screen.getByText("Repository URL")).toBeInTheDocument();
+    expect(screen.getByText("Audit Report")).toBeInTheDocument();
+    expect(screen.getByText(/on-chain contract IDs/i)).toBeInTheDocument();
+    expect(
+      screen.getByRole("link", { name: /Request verification after listing/i }),
+    ).toHaveAttribute("href", "/verify");
+  });
+
+  it("marks completed items visually and tracks required vs optional counts", () => {
+    // The count is rendered as separate JSX text nodes ("4" / "4"), so
+    // check the whole container's normalized text content instead of
+    // trying to match a single element.
+    const { container } = render(
+      <SubmissionChecklist
+        formData={{
+          name: "Soroban Swap",
+          primaryCategory: "defi",
+          websiteUrl: "https://example.com",
+          description: "A description that is definitely long enough.",
+        }}
+      />,
+    );
+    const text = container.textContent?.replace(/\s+/g, "") ?? "";
+    expect(text).toContain("4/4");
+    expect(text).toContain("0/5");
+  });
+
+  it("does not block submission when only optional fields are missing", () => {
+    render(
+      <SubmissionChecklist
+        formData={{
+          name: "Soroban Swap",
+          primaryCategory: "defi",
+          websiteUrl: "https://example.com",
+          description: "A description that is definitely long enough.",
+        }}
+      />,
+    );
+
+    // No "complete required fields" warning once required items are done,
+    // even though every optional item (logo, docs, repo, audit, bounty)
+    // is still missing.
+    expect(
+      screen.queryByText(/Complete all required fields to enable submission/i),
+    ).not.toBeInTheDocument();
+  });
+
+  it("shows the blocking message only while required fields are missing", () => {
+    render(<SubmissionChecklist formData={{}} />);
+
+    expect(
+      screen.getByText(/Complete all required fields to enable submission/i),
+    ).toBeInTheDocument();
+  });
+
+  it("treats category as a required, tracked item", () => {
+    const { container } = render(
+      <SubmissionChecklist
+        formData={{
+          name: "Soroban Swap",
+          websiteUrl: "https://example.com",
+          description: "A description that is definitely long enough.",
+          // primaryCategory intentionally omitted
+        }}
+      />,
+    );
+
+    expect(screen.getByText("Category")).toBeInTheDocument();
+    const text = container.textContent?.replace(/\s+/g, "") ?? "";
+    expect(text).toContain("3/4");
+    expect(
+      screen.getByText(/Complete all required fields to enable submission/i),
+    ).toBeInTheDocument();
+  });
+});

--- a/dongle/components/projects/ProjectForm.tsx
+++ b/dongle/components/projects/ProjectForm.tsx
@@ -300,6 +300,7 @@ export default function ProjectForm({
         <SubmissionChecklist
           formData={{
             name: watchedValues.name,
+            primaryCategory: watchedValues.primaryCategory,
             websiteUrl: watchedValues.websiteUrl,
             githubUrl: watchedValues.githubUrl,
             logoUrl: watchedValues.logoUrl,

--- a/dongle/components/projects/SubmissionChecklist.tsx
+++ b/dongle/components/projects/SubmissionChecklist.tsx
@@ -1,7 +1,8 @@
-"use client";
+﻿"use client";
 
 import React, { useMemo } from "react";
-import { CheckCircle2, Circle, AlertCircle, Info } from "lucide-react";
+import { CheckCircle2, Circle, AlertCircle, Info, ShieldCheck, ArrowRight } from "lucide-react";
+import Link from "next/link";
 import { Card } from "@/components/ui/Card";
 
 export interface ChecklistItem {
@@ -15,6 +16,7 @@ export interface ChecklistItem {
 interface SubmissionChecklistProps {
   formData: {
     name?: string;
+    primaryCategory?: string;
     websiteUrl?: string;
     githubUrl?: string;
     logoUrl?: string;
@@ -35,6 +37,13 @@ export function SubmissionChecklist({ formData, className }: SubmissionChecklist
         description: "Clear, unique name (minimum 3 characters)",
         required: true,
         completed: (formData.name?.trim().length ?? 0) >= 3,
+      },
+      {
+        id: "category",
+        label: "Category",
+        description: "The category that best fits your project",
+        required: true,
+        completed: (formData.primaryCategory?.trim().length ?? 0) > 0,
       },
       {
         id: "website",
@@ -241,6 +250,32 @@ export function SubmissionChecklist({ formData, className }: SubmissionChecklist
               </div>
             </div>
           ))}
+        </div>
+
+        {/* Prepare for Verification */}
+        <div className="p-4 rounded-lg bg-purple-50 dark:bg-purple-950/20 border border-purple-200 dark:border-purple-900">
+          <div className="flex items-start gap-3">
+            <ShieldCheck className="w-5 h-5 text-purple-600 dark:text-purple-400 flex-shrink-0 mt-0.5" />
+            <div className="flex-1 min-w-0">
+              <span className="text-sm font-medium text-purple-900 dark:text-purple-100">
+                Prepare for verification
+              </span>
+              <p className="text-xs text-purple-700 dark:text-purple-300 mt-0.5">
+                Verification isn&apos;t part of this form, but a strong listing
+                is easier to verify. Before you request it, have your{" "}
+                <strong>on-chain contract IDs</strong> ready to reference (in
+                your docs or description), along with any audit reports or
+                other evidence.
+              </p>
+              <Link
+                href="/verify"
+                className="inline-flex items-center gap-1 text-xs font-medium text-purple-700 dark:text-purple-300 hover:underline mt-2"
+              >
+                Request verification after listing
+                <ArrowRight className="w-3 h-3" />
+              </Link>
+            </div>
+          </div>
         </div>
 
         {/* Submission Status */}


### PR DESCRIPTION
## Summary

`SubmissionChecklist` already existed and covered most of what #249 asks for — visually tracked (checkmarks, progress bar, quality score), appears right in the submit/edit form, and doesn't block submission over optional-only gaps. Two real gaps closed:

- **Category** was a truly required field (per the `zod` schema — `primaryCategory: z.string().min(1)`) but had no checklist item at all. Now tracked as required, matching how it's actually validated.
- **Contract IDs** and **verification request** are named in the issue but have no corresponding form field — verification is a separate flow with its own page and fee (`/verify`). Rather than invent fake tracked checkboxes for fields that don't exist, added a distinct "Prepare for verification" guidance panel linking there.

## Acceptance criteria

-  Checklist appears near the submit/edit flow (already did — this just extends it)
-  Completed items are visually tracked (checkmarks/colors/progress bar, already existed; category now included)
-  Doesn't block submission unless required fields are missing (unchanged — optional items never blocked; category joining the required set only blocks if category itself is actually missing)

## Testing

Added `SubmissionChecklist.test.tsx` — no tests existed for this component before. Covers:
- All topics named in #249 render (website, docs, logo, repository, audit, contract IDs guidance, verification link)
- Required vs optional counts track correctly
- Optional-only gaps don't block submission
- Category counts as a required, tracked item

Verified: new tests 5/5 passing, existing `Submit.test.tsx` 14/14 passing (unaffected).

Closes #249