### PR TITLE
fix: add production deployment checklist and preview validation

### DIFF
--- a/.github/workflows/preview-validation.yml
+++ b/.github/workflows/preview-validation.yml
@@ -1,0 +1,70 @@
+name: Preview Validation
+
+# Lightweight checks that preview/production deployments render core routes
+# and that production configuration is present when secrets are supplied.
+#
+# Manual:
+#   gh workflow run preview-validation.yml -f preview_url=https://….vercel.app
+#
+# Or from Actions → Preview Validation → Run workflow
+
+on:
+  workflow_dispatch:
+    inputs:
+      preview_url:
+        description: "Preview or production base URL (e.g. https://….vercel.app)"
+        required: true
+        type: string
+      validate_env:
+        description: "Also run strict env validation (requires repo secrets)"
+        required: false
+        default: false
+        type: boolean
+
+jobs:
+  preview-smoke:
+    name: Smoke-test main routes
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./dongle
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20.19.0"
+
+      - name: Run preview smoke tests
+        env:
+          PREVIEW_URL: ${{ inputs.preview_url }}
+        run: node scripts/preview-smoke.js
+
+  validate-production-env:
+    name: Validate production env
+    if: ${{ inputs.validate_env == true || inputs.validate_env == 'true' }}
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./dongle
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20.19.0"
+
+      - name: Validate required configuration
+        env:
+          NEXT_PUBLIC_PROJECT_REGISTRY_CONTRACT: ${{ secrets.NEXT_PUBLIC_PROJECT_REGISTRY_CONTRACT }}
+          NEXT_PUBLIC_REVIEW_REGISTRY_CONTRACT: ${{ secrets.NEXT_PUBLIC_REVIEW_REGISTRY_CONTRACT }}
+          NEXT_PUBLIC_VERIFICATION_REGISTRY_CONTRACT: ${{ secrets.NEXT_PUBLIC_VERIFICATION_REGISTRY_CONTRACT }}
+          NEXT_PUBLIC_SOROBAN_RPC_URL: ${{ secrets.NEXT_PUBLIC_SOROBAN_RPC_URL }}
+          NEXT_PUBLIC_SOROBAN_NETWORK_PASSPHRASE: ${{ secrets.NEXT_PUBLIC_SOROBAN_NETWORK_PASSPHRASE }}
+        run: node scripts/validate-production-env.js

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Dongle lets users browse and rate dApps, lets project owners list and verify the
 - [Environment Variables](#environment-variables)
 - [Wallet & Network Setup](#wallet--network-setup)
 - [Available Scripts](#available-scripts)
+- [Production Deployment](#production-deployment)
 - [Known Limitations](#known-limitations)
 
 ## What Dongle Does
@@ -111,16 +112,18 @@ cp .env.example .env.local
 
 ## Available Scripts
 
-| Command           | Description                                                       |
-| ----------------- | ----------------------------------------------------------------- |
-| `pnpm dev`        | Start the Next.js dev server.                                     |
-| `pnpm build`      | Build the production bundle.                                      |
-| `pnpm start`      | Serve the production build.                                       |
-| `pnpm lint`       | Run ESLint (`--max-warnings 0`, so any warning fails the check).  |
-| `pnpm typecheck`  | Run `tsc --noEmit` to check types without emitting output.        |
-| `pnpm test`       | Run the Vitest suite once.                                        |
-| `pnpm test:watch` | Run Vitest in watch mode.                                         |
-| `pnpm audit`      | Run the project's custom audit script (`scripts/audit-check.js`). |
+| Command              | Description                                                       |
+| -------------------- | ----------------------------------------------------------------- |
+| `pnpm dev`           | Start the Next.js dev server.                                     |
+| `pnpm build`         | Build the production bundle.                                      |
+| `pnpm start`         | Serve the production build.                                       |
+| `pnpm lint`          | Run ESLint (`--max-warnings 0`, so any warning fails the check).  |
+| `pnpm typecheck`     | Run `tsc --noEmit` to check types without emitting output.        |
+| `pnpm test`          | Run the Vitest suite once.                                        |
+| `pnpm test:watch`    | Run Vitest in watch mode.                                         |
+| `pnpm audit`         | Run the project's custom audit script (`scripts/audit-check.js`). |
+| `pnpm validate:env`  | Fail if production env vars are missing, invalid, or placeholders.|
+| `pnpm preview:smoke` | HTTP smoke-test main routes against `PREVIEW_URL`.                |
 
 Before pushing or opening a PR, it's worth running lint, typecheck, and test together:
 
@@ -128,9 +131,21 @@ Before pushing or opening a PR, it's worth running lint, typecheck, and test tog
 pnpm lint && pnpm typecheck && pnpm test
 ```
 
+## Production Deployment
+
+For Vercel (or similar) deploys — environment setup, wallet/network assumptions, preview route validation, and smoke tests — see **[`dongle/DEPLOYMENT.md`](./dongle/DEPLOYMENT.md)**.
+
+Quick checks before promoting a preview:
+
+```bash
+cd dongle
+npm run validate:env
+PREVIEW_URL=https://your-preview.vercel.app npm run preview:smoke
+```
+
 ## Known Limitations
 
-- **Placeholder contract IDs in development.** If the three `NEXT_PUBLIC_*_CONTRACT` variables are left unset, the app falls back to placeholder contract addresses rather than real deployed contracts. On-chain reads/writes against these placeholders will not reflect real data — set real testnet or mainnet contract IDs to exercise actual contract behavior.
+- **Placeholder contract IDs in development.** If the three `NEXT_PUBLIC_*_CONTRACT` variables are left unset, the app falls back to placeholder contract addresses rather than real deployed contracts. On-chain reads/writes against these placeholders will not reflect real data — set real testnet or mainnet contract IDs to exercise actual contract behavior. Production builds reject the placeholder and surface a config banner if it was somehow inlined.
 - **Testnet-first.** Defaults (RPC URL, network passphrase) point at Stellar testnet. Mainnet use requires explicitly overriding all network-related env vars, and has not been the primary target during development.
 - **Off-chain evidence storage.** Written reviews and verification evidence are stored on IPFS and referenced on-chain by CID — the frontend depends on that off-chain content being pinned/available; it is not itself persisted on-chain.
 - **Admin access is allowlist-based.** Admin routes are gated purely by the `NEXT_PUBLIC_ADMIN_ALLOWLIST` public keys; leaving it empty disables the admin dashboard entirely rather than restricting it.

--- a/dongle/.env.example
+++ b/dongle/.env.example
@@ -1,5 +1,6 @@
 # Copy this file to `.env.local` in the `dongle/` directory and customize as needed.
-# See README.md "Environment Variables" for full documentation.
+# See README.md "Environment Variables" and DEPLOYMENT.md for production checklist.
+# Run `npm run validate:env` before promoting a preview — placeholders fail that check.
 
 # ============================================
 # SOROBAN SMART CONTRACTS (required in production)

--- a/dongle/DEPLOYMENT.md
+++ b/dongle/DEPLOYMENT.md
@@ -1,0 +1,124 @@
+# Production Deployment Checklist
+
+App-specific runbook for deploying Dongle (Next.js app in `dongle/`) to Vercel or another host. Use this before promoting a preview to production.
+
+## Prerequisites
+
+- [ ] Node.js ≥ 20 and npm ≥ 10 available for local smoke checks
+- [ ] Freighter wallet available for a manual wallet/network smoke test
+- [ ] Real Soroban contract IDs for Project, Review, and Verification registries
+- [ ] Hosting project root set to **`dongle/`** (Vercel: Settings → General → Root Directory)
+- [ ] Preview and Production environment variables configured separately in the host
+
+## Environment setup
+
+Copy from `.env.example`, then set real values for the target network:
+
+| Variable | Production | Notes |
+| -------- | ---------- | ----- |
+| `NEXT_PUBLIC_PROJECT_REGISTRY_CONTRACT` | **Required** | 56-char Stellar contract ID (`C` + 55 base32). Must **not** be the all-A placeholder. |
+| `NEXT_PUBLIC_REVIEW_REGISTRY_CONTRACT` | **Required** | Same format as above. |
+| `NEXT_PUBLIC_VERIFICATION_REGISTRY_CONTRACT` | **Required** | Same format as above. |
+| `NEXT_PUBLIC_SOROBAN_RPC_URL` | **Required** | e.g. testnet `https://soroban-testnet.stellar.org:443` or your mainnet RPC. |
+| `NEXT_PUBLIC_SOROBAN_NETWORK_PASSPHRASE` | **Required** | Must match Freighter’s network. Testnet: `Test SDF Network ; September 2015`. Mainnet: `Public Global Stellar Network ; September 2015`. |
+| `NEXT_PUBLIC_ADMIN_ALLOWLIST` | Optional | Comma-separated `G…` public keys. Empty disables admin access. |
+| `NEXT_PUBLIC_REVIEW_PERSISTENCE` | Optional | Set to `api` for server persistence; leave unset for localStorage (dev-only). |
+
+### Validate config before deploy
+
+From `dongle/`:
+
+```bash
+npm run validate:env
+```
+
+This fails clearly when required variables are missing, malformed, or still set to the development placeholder contract ID.
+
+On Vercel, set the same variables under **Project → Settings → Environment Variables** for **Preview** and **Production**. `NEXT_PUBLIC_*` values are inlined at **build** time — changing them requires a redeploy.
+
+## Wallet & network assumptions
+
+- [ ] Freighter is installed and unlocked
+- [ ] Freighter network matches `NEXT_PUBLIC_SOROBAN_NETWORK_PASSPHRASE`
+- [ ] Read-only routes work without a wallet; write flows (review, verify, admin) require a connected wallet
+- [ ] Testnet accounts are funded via [Friendbot](https://friendbot.stellar.org/) when exercising fee-paying flows
+- [ ] A network mismatch shows the in-app banner; do not promote if Freighter and app passphrase disagree
+
+## Pre-deploy checklist
+
+1. [ ] `npm ci`
+2. [ ] `npm run lint && npm run typecheck && npm test`
+3. [ ] `npm run validate:env` (with production/preview env loaded)
+4. [ ] `npm run build`
+5. [ ] Confirm contract IDs point at the intended network (testnet vs mainnet)
+6. [ ] Confirm admin allowlist is intentional (empty = no admin UI access)
+
+## Preview validation (main routes)
+
+After a preview deploy (or against a local production server), confirm core routes render HTTP 200:
+
+```bash
+# Local production-like check
+npm run build && npm run start
+# in another terminal:
+PREVIEW_URL=http://localhost:3000 npm run preview:smoke
+
+# Against a Vercel preview URL
+PREVIEW_URL=https://your-preview.vercel.app npm run preview:smoke
+```
+
+Routes checked by default:
+
+- `/` (landing)
+- `/discover`
+- `/listing`
+- `/reviews`
+- `/verify`
+- `/projects/new`
+- `/docs`
+- `/profile`
+- `/compare`
+
+CI can run the same script via the **Preview Validation** workflow (`workflow_dispatch` or after a preview URL is known).
+
+### Manual smoke tests
+
+- [ ] Landing loads brand + CTA
+- [ ] Discover lists/filters without a wallet
+- [ ] Project detail opens from discover/listing (when data exists)
+- [ ] Connect wallet → Freighter prompt → correct network badge
+- [ ] Review / verify pages render (submit only if contracts are real)
+- [ ] Admin page: allowlisted wallet sees dashboard; others are gated
+- [ ] No production-config error banner (placeholder contracts rejected)
+
+## Missing configuration must fail loudly
+
+- **`npm run validate:env`** exits non-zero with a field-by-field report
+- **Production runtime** rejects missing/invalid env and the all-A placeholder contract IDs (see `constants/contracts.ts`)
+- **UI** shows a production config banner if the build somehow ships with placeholder contracts so users are not sent into broken on-chain flows
+
+Do **not** promote a preview that fails `validate:env` or `preview:smoke`.
+
+## Promote to production
+
+1. [ ] Preview checklist passed
+2. [ ] Production env vars set (not Preview-only)
+3. [ ] Redeploy production (or merge to `main` if auto-deploy is enabled)
+4. [ ] Re-run `PREVIEW_URL=<production-url> npm run preview:smoke`
+5. [ ] Spot-check Freighter on the production network passphrase
+
+## Troubleshooting
+
+| Symptom | Likely cause | Fix |
+| ------- | ------------ | --- |
+| `ENVIRONMENT CONFIGURATION ERROR` at startup | Missing/invalid env | Set vars in host; run `validate:env` |
+| Config banner about placeholder contracts | Dev placeholder still inlined | Set real contract IDs and redeploy |
+| Wallet txs rejected by RPC | Passphrase / network mismatch | Align Freighter with `NEXT_PUBLIC_SOROBAN_NETWORK_PASSPHRASE` |
+| Preview smoke 404s | Wrong Root Directory | Set Vercel root to `dongle/` |
+| Build OK in CI but prod broken | CI build is permissive without secrets | Always run `validate:env` with real env before promote |
+
+## Related docs
+
+- [README.md](./README.md) — local setup and env table
+- [SETUP.md](./SETUP.md) — dependency / platform install notes
+- [`.env.example`](./.env.example) — variable templates

--- a/dongle/__tests__/components/ProductionConfigBanner.test.tsx
+++ b/dongle/__tests__/components/ProductionConfigBanner.test.tsx
@@ -1,0 +1,75 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+
+const PLACEHOLDER = "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
+const REAL = "CBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB";
+
+describe("ProductionConfigBanner", () => {
+  afterEach(() => {
+    vi.resetModules();
+    vi.doUnmock("@/constants/contracts");
+    vi.unstubAllEnvs();
+  });
+
+  it("renders nothing in development", async () => {
+    vi.stubEnv("NODE_ENV", "development");
+    vi.doMock("@/constants/contracts", () => ({
+      DONGLE_CONTRACTS: {
+        PROJECT_REGISTRY: PLACEHOLDER,
+        REVIEW_REGISTRY: PLACEHOLDER,
+        VERIFICATION_REGISTRY: PLACEHOLDER,
+      },
+      hasPlaceholderContracts: () => true,
+    }));
+
+    const { default: ProductionConfigBanner } = await import(
+      "../../components/layout/ProductionConfigBanner"
+    );
+    const { container } = render(<ProductionConfigBanner />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("shows an alert when production still has placeholder contracts", async () => {
+    vi.stubEnv("NODE_ENV", "production");
+    vi.doMock("@/constants/contracts", () => ({
+      DONGLE_CONTRACTS: {
+        PROJECT_REGISTRY: PLACEHOLDER,
+        REVIEW_REGISTRY: PLACEHOLDER,
+        VERIFICATION_REGISTRY: PLACEHOLDER,
+      },
+      hasPlaceholderContracts: () => true,
+    }));
+
+    const { default: ProductionConfigBanner } = await import(
+      "../../components/layout/ProductionConfigBanner"
+    );
+    render(<ProductionConfigBanner />);
+    expect(
+      screen.getByRole("alert"),
+    ).toHaveTextContent(/Production configuration incomplete/i);
+    expect(
+      screen.getByRole("link", { name: /Deployment checklist/i }),
+    ).toHaveAttribute(
+      "href",
+      expect.stringContaining("DEPLOYMENT.md"),
+    );
+  });
+
+  it("renders nothing when production contracts are real", async () => {
+    vi.stubEnv("NODE_ENV", "production");
+    vi.doMock("@/constants/contracts", () => ({
+      DONGLE_CONTRACTS: {
+        PROJECT_REGISTRY: REAL,
+        REVIEW_REGISTRY: REAL,
+        VERIFICATION_REGISTRY: REAL,
+      },
+      hasPlaceholderContracts: () => false,
+    }));
+
+    const { default: ProductionConfigBanner } = await import(
+      "../../components/layout/ProductionConfigBanner"
+    );
+    const { container } = render(<ProductionConfigBanner />);
+    expect(container).toBeEmptyDOMElement();
+  });
+});

--- a/dongle/__tests__/constants/contracts.test.ts
+++ b/dongle/__tests__/constants/contracts.test.ts
@@ -6,6 +6,7 @@ import {
   DEV_CONTRACT_PLACEHOLDER,
   DEV_RPC_URL,
   DEV_NETWORK_PASSPHRASE,
+  hasPlaceholderContracts,
 } from "../../constants/contracts";
 
 // ---------------------------------------------------------------------------
@@ -14,12 +15,14 @@ import {
 
 const VALID_CONTRACT = "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
 const VALID_CONTRACT_2 = "CBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB";
+const VALID_CONTRACT_3 = "CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC";
 const VALID_PUBLIC_KEY = "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
 
+/** Production-safe env — must not use the all-A development placeholder. */
 const FULL_VALID_ENV = {
-  NEXT_PUBLIC_PROJECT_REGISTRY_CONTRACT: VALID_CONTRACT,
-  NEXT_PUBLIC_REVIEW_REGISTRY_CONTRACT: VALID_CONTRACT,
-  NEXT_PUBLIC_VERIFICATION_REGISTRY_CONTRACT: VALID_CONTRACT,
+  NEXT_PUBLIC_PROJECT_REGISTRY_CONTRACT: VALID_CONTRACT_2,
+  NEXT_PUBLIC_REVIEW_REGISTRY_CONTRACT: VALID_CONTRACT_3,
+  NEXT_PUBLIC_VERIFICATION_REGISTRY_CONTRACT: VALID_CONTRACT_2,
   NEXT_PUBLIC_SOROBAN_RPC_URL: "https://soroban-testnet.stellar.org:443",
   NEXT_PUBLIC_SOROBAN_NETWORK_PASSPHRASE: "Test SDF Network ; September 2015",
 };
@@ -179,13 +182,25 @@ describe("parseEnv — production mode", () => {
 
   it("succeeds with a fully valid environment", () => {
     const env = parseEnv(FULL_VALID_ENV, false);
-    expect(env.NEXT_PUBLIC_PROJECT_REGISTRY_CONTRACT).toBe(VALID_CONTRACT);
+    expect(env.NEXT_PUBLIC_PROJECT_REGISTRY_CONTRACT).toBe(VALID_CONTRACT_2);
     expect(env.NEXT_PUBLIC_SOROBAN_RPC_URL).toBe(
       "https://soroban-testnet.stellar.org:443",
     );
     expect(env.NEXT_PUBLIC_SOROBAN_NETWORK_PASSPHRASE).toBe(
       "Test SDF Network ; September 2015",
     );
+  });
+
+  it("rejects the development placeholder contract ID in production", () => {
+    expect(() =>
+      parseEnv(
+        {
+          ...FULL_VALID_ENV,
+          NEXT_PUBLIC_PROJECT_REGISTRY_CONTRACT: DEV_CONTRACT_PLACEHOLDER,
+        },
+        false,
+      ),
+    ).toThrow();
   });
 
   it("throws on an invalid contract ID format in production", () => {
@@ -229,7 +244,7 @@ describe("parseEnv — production mode", () => {
     expect(() =>
       parseEnv(
         {
-          NEXT_PUBLIC_PROJECT_REGISTRY_CONTRACT: VALID_CONTRACT,
+          NEXT_PUBLIC_PROJECT_REGISTRY_CONTRACT: VALID_CONTRACT_2,
           // REVIEW and VERIFICATION missing
           NEXT_PUBLIC_SOROBAN_RPC_URL: "https://soroban-testnet.stellar.org:443",
           NEXT_PUBLIC_SOROBAN_NETWORK_PASSPHRASE: "Test SDF Network ; September 2015",
@@ -263,5 +278,27 @@ describe("exported constants", () => {
 
   it("DEV_NETWORK_PASSPHRASE is a non-empty string", () => {
     expect(DEV_NETWORK_PASSPHRASE.length).toBeGreaterThan(0);
+  });
+});
+
+describe("hasPlaceholderContracts", () => {
+  it("returns true when any contract is the all-A placeholder", () => {
+    expect(
+      hasPlaceholderContracts({
+        PROJECT_REGISTRY: DEV_CONTRACT_PLACEHOLDER,
+        REVIEW_REGISTRY: VALID_CONTRACT_2,
+        VERIFICATION_REGISTRY: VALID_CONTRACT_2,
+      }),
+    ).toBe(true);
+  });
+
+  it("returns false when all contracts are real IDs", () => {
+    expect(
+      hasPlaceholderContracts({
+        PROJECT_REGISTRY: VALID_CONTRACT_2,
+        REVIEW_REGISTRY: VALID_CONTRACT_3,
+        VERIFICATION_REGISTRY: VALID_CONTRACT_2,
+      }),
+    ).toBe(false);
   });
 });

--- a/dongle/app/admin/page.tsx
+++ b/dongle/app/admin/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useMemo, useEffect } from "react";
+import { useState, useEffect } from "react";
 import { toast } from "sonner";
 import AddressDisplay from "@/components/ui/AddressDisplay";
 import WalletStatePanel, {
@@ -36,24 +36,25 @@ export default function AdminDashboard() {
   const [fee, setFee] = useState(1.5);
   const [activeTab, setActiveTab] = useState<"verification" | "reports">("verification");
   const [reports, setReports] = useState<ReviewReport[]>([]);
+  const [reviews, setReviews] = useState<Review[]>([]);
   const [moderationLog, setModerationLog] = useState<ModerationAction[]>([]);
   const [moderationReason, setModerationReason] = useState<Record<string, string>>({});
   const [expandedReport, setExpandedReport] = useState<string | null>(null);
 
-  const isAdmin = useMemo(
-    () =>
-      gate.state === "ready" &&
-      Boolean(gate.publicKey) &&
-      ADMIN_ALLOWLIST.includes(gate.publicKey!),
-    [gate.state, gate.publicKey],
-  );
-
-  // Load reports and moderation log
+  // Load reports, reviews, and moderation log
   useEffect(() => {
-    if (isAdmin) {
-      setReports(reviewReportService.getReports());
-      setModerationLog(reviewReportService.getModerationLog());
-    }
+    if (!isAdmin) return;
+
+    let cancelled = false;
+    setReports(reviewReportService.getReports());
+    setModerationLog(reviewReportService.getModerationLog());
+    void reviewService.getReviews().then((loaded) => {
+      if (!cancelled) setReviews(loaded);
+    });
+
+    return () => {
+      cancelled = true;
+    };
   }, [isAdmin]);
 
   const handleAction = (id: string, status: "approved" | "rejected") => {
@@ -97,7 +98,7 @@ export default function AdminDashboard() {
   };
 
   const getReviewForReport = (reviewId: string): Review | undefined => {
-    return reviewService.getReviews().find((r) => r.id === reviewId);
+    return reviews.find((r) => r.id === reviewId);
   };
 
   const getModerationActionsForReport = (reportId: string): ModerationAction[] => {
@@ -146,16 +147,6 @@ export default function AdminDashboard() {
   }
 
   // ── 3. Authorized — render dashboard ────────────────────────────────────────
-  const handleAction = (id: string, status: "approved" | "rejected") => {
-    setRequests((prev) =>
-      prev.map((req) => (req.id === id ? { ...req, status } : req)),
-    );
-  };
-
-  const handleSaveFee = () => {
-    toast.success(`Verification fee updated to ${fee} XLM`);
-  };
-
   return (
     <div className="container mx-auto px-4 py-12">
       <div className="max-w-6xl mx-auto">

--- a/dongle/components/layout/LayoutWrapper.tsx
+++ b/dongle/components/layout/LayoutWrapper.tsx
@@ -3,6 +3,7 @@
 import Navbar from "./Navbar";
 import Footer from "./Footer";
 import NetworkMismatchBanner from "./NetworkMismatchBanner";
+import ProductionConfigBanner from "./ProductionConfigBanner";
 import { ComparisonFloatingButton } from "@/components/compare/ComparisonFloatingButton";
 
 interface LayoutWrapperProps {
@@ -13,6 +14,7 @@ export default function LayoutWrapper({ children }: LayoutWrapperProps) {
   return (
     <div className="flex flex-col min-h-screen">
       <Navbar />
+      <ProductionConfigBanner />
       <NetworkMismatchBanner />
       <main className="grow pt-16">
         {children}

--- a/dongle/components/layout/ProductionConfigBanner.tsx
+++ b/dongle/components/layout/ProductionConfigBanner.tsx
@@ -1,0 +1,43 @@
+"use client";
+
+import { DONGLE_CONTRACTS, hasPlaceholderContracts } from "@/constants/contracts";
+
+/**
+ * Surfaces a hard-to-miss warning when a production build still has
+ * development placeholder contract IDs, so users are not sent into
+ * broken on-chain flows.
+ */
+export default function ProductionConfigBanner() {
+  // Only relevant outside local development.
+  if (process.env.NODE_ENV === "development") {
+    return null;
+  }
+
+  if (!hasPlaceholderContracts(DONGLE_CONTRACTS)) {
+    return null;
+  }
+
+  return (
+    <div
+      role="alert"
+      className="border-b border-red-500/40 bg-red-600 text-white"
+    >
+      <div className="mx-auto flex max-w-6xl flex-col gap-1 px-4 py-3 text-sm sm:flex-row sm:items-center sm:justify-between">
+        <p className="font-medium">
+          Production configuration incomplete: contract IDs are still set to
+          development placeholders. On-chain reads and writes will not work
+          until real Soroban contract IDs are configured and the app is
+          redeployed.
+        </p>
+        <a
+          href="https://github.com/HubDApp/Dongle-frontend/blob/main/dongle/DEPLOYMENT.md"
+          className="shrink-0 font-semibold underline underline-offset-2 hover:text-red-100"
+          target="_blank"
+          rel="noreferrer"
+        >
+          Deployment checklist
+        </a>
+      </div>
+    </div>
+  );
+}

--- a/dongle/constants/contracts.ts
+++ b/dongle/constants/contracts.ts
@@ -40,10 +40,22 @@ export const DEV_NETWORK_PASSPHRASE = "Test SDF Network ; September 2015";
  *               defaults.  When false (production / build), every field is
  *               required and must be explicitly set.
  */
+/**
+ * Production contract IDs must be real deployments — the all-A placeholder
+ * is structurally valid but must never ship to users.
+ */
+export const ProductionContractIdSchema = ContractIdSchema.refine(
+  (id) => id !== DEV_CONTRACT_PLACEHOLDER,
+  {
+    message:
+      "Development placeholder contract ID is not allowed in production — set a real deployed contract ID",
+  },
+);
+
 export const getEnvSchema = (isDev: boolean) => {
   const contractField = isDev
     ? ContractIdSchema.default(DEV_CONTRACT_PLACEHOLDER)
-    : ContractIdSchema;
+    : ProductionContractIdSchema;
 
   const urlField = isDev
     ? z.string().url("NEXT_PUBLIC_SOROBAN_RPC_URL must be a valid URL").default(DEV_RPC_URL)
@@ -61,6 +73,19 @@ export const getEnvSchema = (isDev: boolean) => {
     NEXT_PUBLIC_SOROBAN_NETWORK_PASSPHRASE: passphraseField,
   });
 };
+
+/**
+ * True when any configured contract ID is still the safe development placeholder.
+ * Used by the UI to fail clearly before users hit broken on-chain flows.
+ */
+export const hasPlaceholderContracts = (contracts: {
+  PROJECT_REGISTRY: string;
+  REVIEW_REGISTRY: string;
+  VERIFICATION_REGISTRY: string;
+}): boolean =>
+  contracts.PROJECT_REGISTRY === DEV_CONTRACT_PLACEHOLDER ||
+  contracts.REVIEW_REGISTRY === DEV_CONTRACT_PLACEHOLDER ||
+  contracts.VERIFICATION_REGISTRY === DEV_CONTRACT_PLACEHOLDER;
 
 // ─── Parser ───────────────────────────────────────────────────────────────────
 
@@ -103,10 +128,10 @@ export const parseEnv = (
       "",
       isDev
         ? "In development, unset variables fall back to safe defaults."
-        : "In production ALL variables must be explicitly set in your",
-      isDev ? "" : "deployment environment or .env file.",
+        : "In production ALL variables must be explicitly set (real contract",
+      isDev ? "" : "IDs — not the all-A placeholder) in your deployment environment.",
       "",
-      "See dongle/.env.example for the full list of required variables.",
+      "See dongle/DEPLOYMENT.md and dongle/.env.example.",
       "",
     ].join("\n"),
   );

--- a/dongle/package.json
+++ b/dongle/package.json
@@ -14,7 +14,9 @@
     "test": "vitest --run",
     "test:watch": "vitest",
     "typecheck": "tsc --noEmit",
-    "audit": "node scripts/audit-check.js"
+    "audit": "node scripts/audit-check.js",
+    "validate:env": "node scripts/validate-production-env.js",
+    "preview:smoke": "node scripts/preview-smoke.js"
   },
   "dependencies": {
     "@hookform/resolvers": "^5.2.2",

--- a/dongle/scripts/preview-smoke.js
+++ b/dongle/scripts/preview-smoke.js
@@ -1,0 +1,135 @@
+#!/usr/bin/env node
+/**
+ * Lightweight preview/production smoke test.
+ *
+ * Confirms core Dongle routes render (HTTP 2xx) against PREVIEW_URL.
+ *
+ * Usage:
+ *   PREVIEW_URL=http://localhost:3000 npm run preview:smoke
+ *   PREVIEW_URL=https://your-app.vercel.app npm run preview:smoke
+ *
+ * Optional:
+ *   ROUTES=/,/discover   — comma-separated path override
+ *   TIMEOUT_MS=15000     — per-request timeout
+ */
+
+const DEFAULT_ROUTES = [
+  "/",
+  "/discover",
+  "/listing",
+  "/reviews",
+  "/verify",
+  "/projects/new",
+  "/docs",
+  "/profile",
+  "/compare",
+];
+
+function parseRoutes() {
+  if (process.env.ROUTES && process.env.ROUTES.trim()) {
+    return process.env.ROUTES.split(",")
+      .map((r) => r.trim())
+      .filter(Boolean)
+      .map((r) => (r.startsWith("/") ? r : `/${r}`));
+  }
+  return DEFAULT_ROUTES;
+}
+
+async function checkRoute(baseUrl, route, timeoutMs) {
+  const url = new URL(route, baseUrl).toString();
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+
+  try {
+    const res = await fetch(url, {
+      method: "GET",
+      redirect: "follow",
+      signal: controller.signal,
+      headers: {
+        Accept: "text/html,application/xhtml+xml",
+        "User-Agent": "dongle-preview-smoke/1.0",
+      },
+    });
+
+    const ok = res.status >= 200 && res.status < 400;
+    return { route, url, status: res.status, ok, error: null };
+  } catch (err) {
+    return {
+      route,
+      url,
+      status: 0,
+      ok: false,
+      error: err.name === "AbortError" ? "timeout" : err.message,
+    };
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+async function main() {
+  const previewUrl = process.env.PREVIEW_URL || process.env.BASE_URL;
+  if (!previewUrl) {
+    console.error(`
+╔══════════════════════════════════════════════════════════════╗
+║          PREVIEW SMOKE TEST — MISSING URL                    ║
+╚══════════════════════════════════════════════════════════════╝
+
+Set PREVIEW_URL (or BASE_URL) to the deployment origin, e.g.:
+
+  PREVIEW_URL=https://your-preview.vercel.app npm run preview:smoke
+  PREVIEW_URL=http://localhost:3000 npm run preview:smoke
+
+See dongle/DEPLOYMENT.md.
+`);
+    process.exit(1);
+  }
+
+  let base;
+  try {
+    base = new URL(previewUrl);
+  } catch {
+    console.error(`Invalid PREVIEW_URL: ${previewUrl}`);
+    process.exit(1);
+  }
+
+  // Normalize to origin (strip trailing path)
+  const origin = base.origin;
+  const timeoutMs = Number(process.env.TIMEOUT_MS || 15000);
+  const routes = parseRoutes();
+
+  console.log(`Preview smoke test → ${origin}`);
+  console.log(`Routes (${routes.length}): ${routes.join(", ")}\n`);
+
+  const results = [];
+  for (const route of routes) {
+    const result = await checkRoute(origin, route, timeoutMs);
+    results.push(result);
+    const mark = result.ok ? "✓" : "✗";
+    const detail = result.error
+      ? result.error
+      : `HTTP ${result.status}`;
+    console.log(`  ${mark} ${route.padEnd(20)} ${detail}`);
+  }
+
+  const failed = results.filter((r) => !r.ok);
+  console.log("");
+
+  if (failed.length > 0) {
+    console.error(
+      `Preview validation failed: ${failed.length}/${results.length} route(s) did not render.`,
+    );
+    for (const f of failed) {
+      console.error(`  - ${f.route} (${f.url}): ${f.error || `HTTP ${f.status}`}`);
+    }
+    process.exit(1);
+  }
+
+  console.log(
+    `✓ Preview validation passed: all ${results.length} main routes rendered.`,
+  );
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/dongle/scripts/validate-production-env.js
+++ b/dongle/scripts/validate-production-env.js
@@ -1,0 +1,139 @@
+#!/usr/bin/env node
+/**
+ * Validates Dongle production/preview environment configuration.
+ *
+ * Fails clearly when required NEXT_PUBLIC_* vars are missing, malformed,
+ * or still set to the development placeholder contract ID.
+ *
+ * Usage (from dongle/):
+ *   npm run validate:env
+ *   node scripts/validate-production-env.js
+ *
+ * Optional: load a dotenv-style file first via ENV_FILE=.env.local
+ */
+
+const fs = require("fs");
+const path = require("path");
+
+const CONTRACT_ID_RE = /^C[A-Z2-7]{55}$/;
+const DEV_CONTRACT_PLACEHOLDER =
+  "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
+
+const REQUIRED = [
+  {
+    name: "NEXT_PUBLIC_PROJECT_REGISTRY_CONTRACT",
+    validate: validateContractId,
+  },
+  {
+    name: "NEXT_PUBLIC_REVIEW_REGISTRY_CONTRACT",
+    validate: validateContractId,
+  },
+  {
+    name: "NEXT_PUBLIC_VERIFICATION_REGISTRY_CONTRACT",
+    validate: validateContractId,
+  },
+  {
+    name: "NEXT_PUBLIC_SOROBAN_RPC_URL",
+    validate: validateUrl,
+  },
+  {
+    name: "NEXT_PUBLIC_SOROBAN_NETWORK_PASSPHRASE",
+    validate: (value) => {
+      if (!value || !String(value).trim()) {
+        return "must not be empty";
+      }
+      return null;
+    },
+  },
+];
+
+function loadEnvFile(filePath) {
+  if (!fs.existsSync(filePath)) {
+    console.error(`ENV_FILE not found: ${filePath}`);
+    process.exit(1);
+  }
+  const raw = fs.readFileSync(filePath, "utf8");
+  for (const line of raw.split(/\r?\n/)) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith("#")) continue;
+    const eq = trimmed.indexOf("=");
+    if (eq <= 0) continue;
+    const key = trimmed.slice(0, eq).trim();
+    let value = trimmed.slice(eq + 1).trim();
+    if (
+      (value.startsWith('"') && value.endsWith('"')) ||
+      (value.startsWith("'") && value.endsWith("'"))
+    ) {
+      value = value.slice(1, -1);
+    }
+    if (process.env[key] === undefined) {
+      process.env[key] = value;
+    }
+  }
+}
+
+function validateContractId(value) {
+  if (!value) return "is required";
+  if (!CONTRACT_ID_RE.test(value)) {
+    return "must be a 56-char Stellar contract ID (C + 55 base32 chars A-Z/2-7)";
+  }
+  if (value === DEV_CONTRACT_PLACEHOLDER) {
+    return "must not use the development placeholder contract ID — set a real deployed contract";
+  }
+  return null;
+}
+
+function validateUrl(value) {
+  if (!value) return "is required";
+  try {
+    // eslint-disable-next-line no-new
+    new URL(value);
+    return null;
+  } catch {
+    return "must be a valid URL";
+  }
+}
+
+function main() {
+  const envFile = process.env.ENV_FILE;
+  if (envFile) {
+    const resolved = path.isAbsolute(envFile)
+      ? envFile
+      : path.join(process.cwd(), envFile);
+    loadEnvFile(resolved);
+  }
+
+  const errors = [];
+  for (const field of REQUIRED) {
+    const message = field.validate(process.env[field.name]);
+    if (message) {
+      errors.push(`  - ${field.name}: ${message}`);
+    }
+  }
+
+  if (errors.length > 0) {
+    console.error(`
+╔══════════════════════════════════════════════════════════════╗
+║     PRODUCTION ENVIRONMENT VALIDATION FAILED                 ║
+╚══════════════════════════════════════════════════════════════╝
+
+The following environment variables are missing or invalid:
+${errors.join("\n")}
+
+Fix these in your hosting provider (Vercel → Environment Variables)
+or local .env before deploying. See dongle/DEPLOYMENT.md.
+`);
+    process.exit(1);
+  }
+
+  console.log("✓ Production environment validation passed.");
+  console.log(
+    `  Network: ${process.env.NEXT_PUBLIC_SOROBAN_NETWORK_PASSPHRASE}`,
+  );
+  console.log(`  RPC:     ${process.env.NEXT_PUBLIC_SOROBAN_RPC_URL}`);
+  console.log(
+    `  Project: ${process.env.NEXT_PUBLIC_PROJECT_REGISTRY_CONTRACT.slice(0, 8)}…`,
+  );
+}
+
+main();


### PR DESCRIPTION
## Summary
- Adds `dongle/DEPLOYMENT.md` covering production env vars, wallet/network assumptions, pre-deploy checks, and smoke tests.
- Adds `npm run validate:env` and `npm run preview:smoke` so missing/placeholder config fails clearly and preview deployments can validate main routes.
- Rejects development placeholder contract IDs in production config, surfaces a production config banner, and wires a Preview Validation GitHub Action.
- Minor admin page cleanup (duplicate symbols + async reviews load) so the app can compile after recent upstream merges.

Closes #225

## Test plan
- [x] `npm test -- __tests__/constants/contracts.test.ts __tests__/components/ProductionConfigBanner.test.tsx` (33 passed)
- [x] `validate:env` fails without env / with placeholder contract IDs
- [x] `validate:env` passes with real contract IDs
- [x] `PREVIEW_URL=http://127.0.0.1:3010 preview:smoke` — all 9 main routes HTTP 200
- [ ] Maintainers: run Preview Validation workflow against a Vercel preview URL