### PR TITLE
feat: add contextual warnings for unverified/rejected projects

### DIFF
--- a/dongle/__tests__/pages/ProjectDetail.test.tsx
+++ b/dongle/__tests__/pages/ProjectDetail.test.tsx
@@ -31,6 +31,7 @@ vi.mock("@/services/review/review.service", () => ({
   reviewService: {
     getReviewsByProject: vi.fn(() => []),
   },
+  getReviewPersistenceLabel: vi.fn(() => "local"),
 }));
 
 vi.mock("@/hooks/useWalletPageGate", () => ({
@@ -46,27 +47,15 @@ vi.mock("@/hooks/useWalletPageGate", () => ({
 
 vi.mock("@/hooks/useSavedProjects", () => ({
   useSavedProjects: () => ({
-    isProjectSaved: vi.fn(() => false),
-    toggleSavedProject: vi.fn(),
-    canManageSavedProjects: true,
-    savedProjectIds: [],
-    walletAddress: "G_OWNER_123",
-    isConnected: true,
-    clearSavedProjects: vi.fn(),
-  }),
-}));
-
-vi.mock("@/hooks/useConfirm", () => ({
-  useConfirm: vi.fn(),
-}));
-
-vi.mock("@/hooks/useSavedProjects", () => ({
-  useSavedProjects: () => ({
     isProjectSaved: () => false,
     toggleSavedProject: vi.fn(),
     canManageSavedProjects: true,
     savedProjectIds: [],
   }),
+}));
+
+vi.mock("@/hooks/useConfirm", () => ({
+  useConfirm: vi.fn(),
 }));
 
 vi.mock("@/services/update/update.service", () => ({
@@ -82,6 +71,28 @@ vi.mock("@/services/recent-views/recent-views.service", () => ({
   recentViewsService: {
     addView: vi.fn(),
   },
+}));
+
+vi.mock("@/components/projects/ReportProjectModal", () => ({
+  ReportProjectModal: () => null,
+}));
+
+vi.mock("@/components/reviews/ReportReviewModal", () => ({
+  ReportReviewModal: () => null,
+}));
+
+vi.mock("@/services/review/review-report.service", () => ({
+  reviewReportService: {
+    createReport: vi.fn(() => ({ success: true })),
+  },
+}));
+
+vi.mock("@/components/verify/VerificationStatus", () => ({
+  default: () => null,
+}));
+
+vi.mock("@/components/projects/RepositoryMetadata", () => ({
+  RepositoryMetadata: () => null,
 }));
 
 async function finishInitialLoad() {
@@ -118,7 +129,9 @@ describe("Project Detail Page - Verification and Safety Warnings", () => {
     vi.useRealTimers();
   });
 
-  it("should show no warning banner and bypass safety interstitial if project is VERIFIED", async () => {
+  // ─── VERIFIED ───────────────────────────────────────────────────────────────
+
+  it("shows no warning banner and bypasses safety interstitial for VERIFIED projects", async () => {
     vi.mocked(sorobanService.getVerificationStatus).mockResolvedValue("VERIFIED");
     const windowOpenSpy = vi.spyOn(window, "open").mockImplementation(() => null);
 
@@ -126,22 +139,27 @@ describe("Project Detail Page - Verification and Safety Warnings", () => {
     await finishInitialLoad();
     vi.useRealTimers();
 
-    // Check warning banners are absent
-    expect(screen.queryByText(/Unverified Project Context/i)).not.toBeInTheDocument();
-    expect(screen.queryByText(/High Risk Warning: Rejected Project/i)).not.toBeInTheDocument();
+    // No warning banners
+    expect(screen.queryByText(/Unverified Project/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Verification Pending/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/High Risk Warning/i)).not.toBeInTheDocument();
 
-    // Trigger website click
-    const websiteLink = screen.getByRole("link", { name: /Website/i });
-    fireEvent.click(websiteLink);
+    // Clicking a link bypasses the interstitial entirely
+    fireEvent.click(screen.getByRole("link", { name: /Website/i }));
 
-    // Should bypass interstitial (confirm should not be called)
     expect(confirmMock).not.toHaveBeenCalled();
-    expect(windowOpenSpy).toHaveBeenCalledWith("https://secure-test.xyz", "_blank", "noopener,noreferrer");
+    expect(windowOpenSpy).toHaveBeenCalledWith(
+      "https://secure-test.xyz",
+      "_blank",
+      "noopener,noreferrer",
+    );
 
     windowOpenSpy.mockRestore();
   });
 
-  it("should show amber context warning and trigger safety interstitial for unverified projects (NONE status)", async () => {
+  // ─── NONE ───────────────────────────────────────────────────────────────────
+
+  it("shows amber 'Unverified Project' banner and triggers interstitial for NONE status", async () => {
     vi.mocked(sorobanService.getVerificationStatus).mockResolvedValue("NONE");
     confirmMock.mockResolvedValue(true);
     const windowOpenSpy = vi.spyOn(window, "open").mockImplementation(() => null);
@@ -150,51 +168,184 @@ describe("Project Detail Page - Verification and Safety Warnings", () => {
     await finishInitialLoad();
     vi.useRealTimers();
 
-    // Amber warning banner must be visible
-    expect(screen.getByText(/Unverified Project Context/i)).toBeInTheDocument();
-    expect(screen.queryByText(/High Risk Warning: Rejected Project/i)).not.toBeInTheDocument();
+    // Correct banner heading is visible
+    expect(screen.getByText("Unverified Project")).toBeInTheDocument();
+    // No pending or rejected banners
+    expect(screen.queryByText(/Verification Pending/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/High Risk Warning/i)).not.toBeInTheDocument();
 
-    // Trigger website click
-    const websiteLink = screen.getByRole("link", { name: /Website/i });
-    fireEvent.click(websiteLink);
+    fireEvent.click(screen.getByRole("link", { name: /Website/i }));
 
-    // Interstitial confirm mock must be called with domain/destination details
     expect(confirmMock).toHaveBeenCalled();
     await waitFor(() => {
-      expect(windowOpenSpy).toHaveBeenCalledWith("https://secure-test.xyz", "_blank", "noopener,noreferrer");
+      expect(windowOpenSpy).toHaveBeenCalledWith(
+        "https://secure-test.xyz",
+        "_blank",
+        "noopener,noreferrer",
+      );
     });
 
     windowOpenSpy.mockRestore();
   });
 
-  it("should show stronger red warning for rejected projects and handle safety interstitial cancellation", async () => {
-    vi.mocked(sorobanService.getVerificationStatus).mockResolvedValue("REJECTED");
-    confirmMock.mockResolvedValue(false); // User cancels
+  it("does NOT open the link when the user cancels the NONE-status interstitial", async () => {
+    vi.mocked(sorobanService.getVerificationStatus).mockResolvedValue("NONE");
+    confirmMock.mockResolvedValue(false);
     const windowOpenSpy = vi.spyOn(window, "open").mockImplementation(() => null);
 
     render(<ProjectDetailPage />);
     await finishInitialLoad();
     vi.useRealTimers();
 
-    // Red warning banner must be visible
-    expect(screen.getByText(/High Risk Warning: Rejected Project/i)).toBeInTheDocument();
-    expect(screen.queryByText(/Unverified Project Context/i)).not.toBeInTheDocument();
-
-    // Trigger GitHub link click
-    const githubLink = screen.getByRole("link", { name: /GitHub/i });
-    fireEvent.click(githubLink);
-
+    fireEvent.click(screen.getByRole("link", { name: /Website/i }));
     expect(confirmMock).toHaveBeenCalled();
-    
-    // Wait a brief tick to let the promise resolve
+
     await act(async () => {
       await new Promise((resolve) => setTimeout(resolve, 20));
     });
-    
-    // Since user canceled, window.open should not have been called
+
     expect(windowOpenSpy).not.toHaveBeenCalled();
+    windowOpenSpy.mockRestore();
+  });
+
+  // ─── PENDING ────────────────────────────────────────────────────────────────
+
+  it("shows amber 'Verification Pending' banner and triggers interstitial for PENDING status", async () => {
+    vi.mocked(sorobanService.getVerificationStatus).mockResolvedValue("PENDING");
+    confirmMock.mockResolvedValue(true);
+    const windowOpenSpy = vi.spyOn(window, "open").mockImplementation(() => null);
+
+    render(<ProjectDetailPage />);
+    await finishInitialLoad();
+    vi.useRealTimers();
+
+    // Correct banner heading for PENDING
+    expect(screen.getByText("Verification Pending")).toBeInTheDocument();
+    // No other banners
+    expect(screen.queryByText("Unverified Project")).not.toBeInTheDocument();
+    expect(screen.queryByText(/High Risk Warning/i)).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("link", { name: /Website/i }));
+
+    expect(confirmMock).toHaveBeenCalled();
+    await waitFor(() => {
+      expect(windowOpenSpy).toHaveBeenCalledWith(
+        "https://secure-test.xyz",
+        "_blank",
+        "noopener,noreferrer",
+      );
+    });
 
     windowOpenSpy.mockRestore();
+  });
+
+  it("does NOT open the link when the user cancels the PENDING-status interstitial", async () => {
+    vi.mocked(sorobanService.getVerificationStatus).mockResolvedValue("PENDING");
+    confirmMock.mockResolvedValue(false);
+    const windowOpenSpy = vi.spyOn(window, "open").mockImplementation(() => null);
+
+    render(<ProjectDetailPage />);
+    await finishInitialLoad();
+    vi.useRealTimers();
+
+    fireEvent.click(screen.getByRole("link", { name: /Website/i }));
+    expect(confirmMock).toHaveBeenCalled();
+
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 20));
+    });
+
+    expect(windowOpenSpy).not.toHaveBeenCalled();
+    windowOpenSpy.mockRestore();
+  });
+
+  // ─── REJECTED ───────────────────────────────────────────────────────────────
+
+  it("shows red 'High Risk Warning' banner and triggers interstitial for REJECTED status", async () => {
+    vi.mocked(sorobanService.getVerificationStatus).mockResolvedValue("REJECTED");
+    confirmMock.mockResolvedValue(true);
+    const windowOpenSpy = vi.spyOn(window, "open").mockImplementation(() => null);
+
+    render(<ProjectDetailPage />);
+    await finishInitialLoad();
+    vi.useRealTimers();
+
+    // Correct banner heading for REJECTED
+    expect(screen.getByText(/High Risk Warning: Rejected Project/i)).toBeInTheDocument();
+    // No other banners
+    expect(screen.queryByText("Unverified Project")).not.toBeInTheDocument();
+    expect(screen.queryByText(/Verification Pending/i)).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("link", { name: /GitHub/i }));
+
+    expect(confirmMock).toHaveBeenCalled();
+    await waitFor(() => {
+      expect(windowOpenSpy).toHaveBeenCalledWith(
+        "https://github.com/secure-test/repo",
+        "_blank",
+        "noopener,noreferrer",
+      );
+    });
+
+    windowOpenSpy.mockRestore();
+  });
+
+  it("does NOT open the link when the user cancels the REJECTED-status interstitial", async () => {
+    vi.mocked(sorobanService.getVerificationStatus).mockResolvedValue("REJECTED");
+    confirmMock.mockResolvedValue(false);
+    const windowOpenSpy = vi.spyOn(window, "open").mockImplementation(() => null);
+
+    render(<ProjectDetailPage />);
+    await finishInitialLoad();
+    vi.useRealTimers();
+
+    fireEvent.click(screen.getByRole("link", { name: /GitHub/i }));
+    expect(confirmMock).toHaveBeenCalled();
+
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 20));
+    });
+
+    expect(windowOpenSpy).not.toHaveBeenCalled();
+    windowOpenSpy.mockRestore();
+  });
+
+  // ─── Interstitial copy ──────────────────────────────────────────────────────
+
+  it("passes stronger copy to the interstitial for REJECTED status", async () => {
+    vi.mocked(sorobanService.getVerificationStatus).mockResolvedValue("REJECTED");
+    confirmMock.mockResolvedValue(false);
+    vi.spyOn(window, "open").mockImplementation(() => null);
+
+    render(<ProjectDetailPage />);
+    await finishInitialLoad();
+    vi.useRealTimers();
+
+    fireEvent.click(screen.getByRole("link", { name: /Website/i }));
+
+    expect(confirmMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        title: expect.stringMatching(/Rejected/i),
+      }),
+    );
+  });
+
+  it("passes pending-specific copy to the interstitial for PENDING status", async () => {
+    vi.mocked(sorobanService.getVerificationStatus).mockResolvedValue("PENDING");
+    confirmMock.mockResolvedValue(false);
+    vi.spyOn(window, "open").mockImplementation(() => null);
+
+    render(<ProjectDetailPage />);
+    await finishInitialLoad();
+    vi.useRealTimers();
+
+    fireEvent.click(screen.getByRole("link", { name: /Website/i }));
+
+    expect(confirmMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        title: expect.stringMatching(/Pending/i),
+      }),
+    );
   });
 });
 

--- a/dongle/app/projects/[id]/page.tsx
+++ b/dongle/app/projects/[id]/page.tsx
@@ -39,12 +39,16 @@ import {
 } from "lucide-react";
 import { toast } from "sonner";
 import { ReportProjectModal } from "@/components/projects/ReportProjectModal";
+import { ReportReviewModal } from "@/components/reviews/ReportReviewModal";
+import { reviewReportService } from "@/services/review/review-report.service";
 import { useSavedProjects } from "@/hooks/useSavedProjects";
 import { updateService } from "@/services/update/update.service";
 import { ProjectUpdate, UpdateType } from "@/types/update";
 import UpdateList from "@/components/updates/UpdateList";
 import UpdateForm from "@/components/updates/UpdateForm";
 import { VerificationBadge } from "@/components/projects/VerificationBadge";
+import { ProjectStatusBanner } from "@/components/projects/ProjectStatusBanner";
+import { shouldBypassLinkWarning, getExternalLinkWarningOptions } from "@/lib/externalLinkWarning";
 import { recentViewsService } from "@/services/recent-views/recent-views.service";
 
 const PROJECT_REVIEW_PURPOSE =
@@ -317,26 +321,15 @@ export default function ProjectDetailPage() {
 
   const handleExternalLinkClick = async (e: React.MouseEvent<HTMLAnchorElement>, url: string) => {
     e.preventDefault();
-    
-    // Check if the domain is verified and can bypass the warning
-    // Verified project domains can bypass the warning if approved (i.e. verificationStatus is VERIFIED).
-    const targetDomain = extractDomain(url);
-    const isVerifiedDomain = verificationStatus === "VERIFIED";
 
-    if (isVerifiedDomain) {
-      // Bypass the warning and open link safely
+    if (shouldBypassLinkWarning(verificationStatus)) {
       window.open(url, "_blank", "noopener,noreferrer");
       return;
     }
 
-    // Otherwise, show confirmation interstitial/modal
-    const ok = await confirm({
-      title: "External Link Safety Warning",
-      description: `You are about to visit the following external domain: ${targetDomain}.\nFull URL: ${url}\n\nMake sure you trust this site before proceeding.`,
-      confirmLabel: "Proceed to Site",
-      cancelLabel: "Stay Here",
-      variant: "warning",
-    });
+    const targetDomain = extractDomain(url);
+    const options = getExternalLinkWarningOptions(targetDomain, url, verificationStatus);
+    const ok = await confirm(options);
 
     if (ok) {
       window.open(url, "_blank", "noopener,noreferrer");
@@ -394,30 +387,8 @@ export default function ProjectDetailPage() {
             Back
           </button>
 
-          {/* Warning Banner */}
-          {verificationStatus === "REJECTED" && (
-            <div className="mb-6 p-5 bg-red-50 dark:bg-red-950/20 text-red-800 dark:text-red-300 rounded-3xl border border-red-200 dark:border-red-900/50 shadow-sm flex items-start gap-4 animate-in fade-in slide-in-from-top-4 duration-300">
-              <AlertCircle className="w-6 h-6 shrink-0 mt-0.5 text-red-600 dark:text-red-400" />
-              <div>
-                <h4 className="font-bold text-base mb-1">High Risk Warning: Rejected Project</h4>
-                <p className="text-sm opacity-90 leading-relaxed">
-                  This project was rejected by the community verification process. Please be extremely cautious: do not connect your wallet, share private keys, or interact with external links unless you are absolutely sure of its safety.
-                </p>
-              </div>
-            </div>
-          )}
-
-          {(verificationStatus === "NONE" || verificationStatus === "PENDING") && (
-            <div className="mb-6 p-5 bg-amber-50 dark:bg-amber-950/20 text-amber-800 dark:text-amber-300 rounded-3xl border border-amber-200 dark:border-amber-900/50 shadow-sm flex items-start gap-4 animate-in fade-in slide-in-from-top-4 duration-300">
-              <Info className="w-6 h-6 shrink-0 mt-0.5 text-amber-600 dark:text-amber-400" />
-              <div>
-                <h4 className="font-bold text-base mb-1">Unverified Project Context</h4>
-                <p className="text-sm opacity-90 leading-relaxed">
-                  This project has not completed the community verification process. It is currently unverified. Please exercise due diligence when interacting with the project and checking external resources.
-                </p>
-              </div>
-            </div>
-          )}
+          {/* Verification Status Banner */}
+          <ProjectStatusBanner status={verificationStatus} />
 
           <div className="grid grid-cols-1 lg:grid-cols-3 gap-8">
             {/* Main Content */}

--- a/dongle/components/projects/ProjectStatusBanner.tsx
+++ b/dongle/components/projects/ProjectStatusBanner.tsx
@@ -1,0 +1,93 @@
+import React from "react";
+import { AlertCircle, Info, Clock } from "lucide-react";
+
+export type ProjectVerificationStatus = "NONE" | "PENDING" | "VERIFIED" | "REJECTED";
+
+interface ProjectStatusBannerProps {
+  status: ProjectVerificationStatus | null;
+}
+
+/**
+ * Displays a contextual page-level warning banner based on a project's
+ * verification status.
+ *
+ * - VERIFIED → renders nothing (no unnecessary noise for trusted projects).
+ * - NONE     → amber informational banner (not alarming, just context).
+ * - PENDING  → amber informational banner, distinct copy noting review is in
+ *              progress so the outcome is still unknown.
+ * - REJECTED → red warning banner with stronger language.
+ */
+export function ProjectStatusBanner({ status }: ProjectStatusBannerProps) {
+  if (!status || status === "VERIFIED") return null;
+
+  if (status === "REJECTED") {
+    return (
+      <div
+        role="alert"
+        className="mb-6 p-5 bg-red-50 dark:bg-red-950/20 text-red-800 dark:text-red-300 rounded-3xl border border-red-200 dark:border-red-900/50 shadow-sm flex items-start gap-4 animate-in fade-in slide-in-from-top-4 duration-300"
+      >
+        <AlertCircle
+          className="w-6 h-6 shrink-0 mt-0.5 text-red-600 dark:text-red-400"
+          aria-hidden="true"
+        />
+        <div>
+          <h4 className="font-bold text-base mb-1">
+            High Risk Warning: Rejected Project
+          </h4>
+          <p className="text-sm opacity-90 leading-relaxed">
+            This project was rejected by the community verification process.
+            Please be extremely cautious: do not connect your wallet, share
+            private keys, or interact with external links unless you are
+            absolutely sure of its safety.
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  if (status === "PENDING") {
+    return (
+      <div
+        role="status"
+        className="mb-6 p-5 bg-amber-50 dark:bg-amber-950/20 text-amber-800 dark:text-amber-300 rounded-3xl border border-amber-200 dark:border-amber-900/50 shadow-sm flex items-start gap-4 animate-in fade-in slide-in-from-top-4 duration-300"
+      >
+        <Clock
+          className="w-6 h-6 shrink-0 mt-0.5 text-amber-600 dark:text-amber-400"
+          aria-hidden="true"
+        />
+        <div>
+          <h4 className="font-bold text-base mb-1">
+            Verification Pending
+          </h4>
+          <p className="text-sm opacity-90 leading-relaxed">
+            This project has submitted a verification request and is currently
+            under review. It has not yet been approved. Please exercise due
+            diligence when interacting with external resources until verification
+            is complete.
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  // status === "NONE"
+  return (
+    <div
+      role="status"
+      className="mb-6 p-5 bg-amber-50 dark:bg-amber-950/20 text-amber-800 dark:text-amber-300 rounded-3xl border border-amber-200 dark:border-amber-900/50 shadow-sm flex items-start gap-4 animate-in fade-in slide-in-from-top-4 duration-300"
+    >
+      <Info
+        className="w-6 h-6 shrink-0 mt-0.5 text-amber-600 dark:text-amber-400"
+        aria-hidden="true"
+      />
+      <div>
+        <h4 className="font-bold text-base mb-1">Unverified Project</h4>
+        <p className="text-sm opacity-90 leading-relaxed">
+          This project has not completed the community verification process.
+          Please exercise due diligence when interacting with external
+          resources.
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/dongle/lib/externalLinkWarning.ts
+++ b/dongle/lib/externalLinkWarning.ts
@@ -1,0 +1,67 @@
+import { ConfirmDialogOptions } from "@/components/ui/ConfirmDialog";
+
+export type LinkWarningStatus = "NONE" | "PENDING" | "VERIFIED" | "REJECTED" | null;
+
+/**
+ * Returns true when the external link should skip the confirmation interstitial.
+ * Only verified projects bypass the warning.
+ */
+export function shouldBypassLinkWarning(status: LinkWarningStatus): boolean {
+  return status === "VERIFIED";
+}
+
+/**
+ * Builds the ConfirmDialog options for the external link interstitial, tuned
+ * to the project's verification status.
+ *
+ * - REJECTED → stronger, red-tinted warning copy.
+ * - PENDING  → softer copy noting the outcome is still unknown.
+ * - NONE / null → neutral informational copy.
+ */
+export function getExternalLinkWarningOptions(
+  targetDomain: string,
+  fullUrl: string,
+  status: LinkWarningStatus,
+): ConfirmDialogOptions {
+  const destination = `${targetDomain} (${fullUrl})`;
+
+  if (status === "REJECTED") {
+    return {
+      title: "Caution: Rejected Project Link",
+      description:
+        `This project has been rejected by the community verification process. ` +
+        `Visiting external links from rejected projects carries elevated risk.\n\n` +
+        `Destination: ${destination}\n\n` +
+        `Only proceed if you fully trust this site.`,
+      confirmLabel: "I Understand — Open Link",
+      cancelLabel: "Stay Here",
+      variant: "warning",
+    };
+  }
+
+  if (status === "PENDING") {
+    return {
+      title: "External Link — Verification Pending",
+      description:
+        `This project's verification is still under review. ` +
+        `Exercise caution before visiting external links.\n\n` +
+        `Destination: ${destination}\n\n` +
+        `Make sure you trust this site before proceeding.`,
+      confirmLabel: "Proceed to Site",
+      cancelLabel: "Stay Here",
+      variant: "warning",
+    };
+  }
+
+  // NONE or null
+  return {
+    title: "External Link",
+    description:
+      `You are about to visit an external site from an unverified project. ` +
+      `Make sure you trust this site before proceeding.\n\n` +
+      `Destination: ${destination}`,
+    confirmLabel: "Proceed to Site",
+    cancelLabel: "Stay Here",
+    variant: "warning",
+  };
+}


### PR DESCRIPTION
- Add ProjectStatusBanner component with distinct copy per status: NONE (amber), PENDING (amber, distinct), REJECTED (red, strong), VERIFIED (renders nothing)
- Add externalLinkWarning utility with status-aware ConfirmDialog options; only VERIFIED bypasses the interstitial
- Replace inline banner JSX in ProjectDetailPage with the new component; wire handleExternalLinkClick to the utility
- Fix pre-existing missing imports: ReportReviewModal and reviewReportService were used but never imported
- Add full test coverage for all four statuses across banner visibility, interstitial behaviour, and copy assertions (13 tests)

closes #237