### PR TITLE
feat: add admin audit log

### DIFF
--- a/dongle/__tests__/components/AuditLogViewer.test.tsx
+++ b/dongle/__tests__/components/AuditLogViewer.test.tsx
@@ -1,0 +1,116 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import AuditLogViewer from "@/components/admin/AuditLogViewer";
+import { AuditLogEntry } from "@/types/audit-log";
+
+// AddressDisplay copies to clipboard — mock the browser API to avoid errors
+Object.defineProperty(navigator, "clipboard", {
+  value: { writeText: vi.fn().mockResolvedValue(undefined) },
+  writable: true,
+  configurable: true,
+});
+
+// ─── Fixtures ─────────────────────────────────────────────────────────────────
+const BASE_ENTRY: AuditLogEntry = {
+  id: "entry-1",
+  actor: "GADMIN1234567890ABCDEF",
+  action: "verification_approved",
+  targetId: "req_1",
+  targetLabel: "Lumina DEX",
+  timestamp: "2024-03-20T10:00:00Z",
+};
+
+function makeEntry(overrides: Partial<AuditLogEntry>): AuditLogEntry {
+  return { ...BASE_ENTRY, ...overrides };
+}
+
+describe("AuditLogViewer", () => {
+  // ── Empty state ──────────────────────────────────────────────────────────────
+
+  it("shows an empty-state message when there are no entries", () => {
+    render(<AuditLogViewer entries={[]} />);
+
+    expect(screen.getByText(/no audit log entries yet/i)).toBeInTheDocument();
+    expect(
+      screen.getByText(/admin actions will appear here/i),
+    ).toBeInTheDocument();
+  });
+
+  it("does not render the table when there are no entries", () => {
+    const { container } = render(<AuditLogViewer entries={[]} />);
+    expect(container.querySelector("table")).toBeNull();
+  });
+
+  // ── Populated state ──────────────────────────────────────────────────────────
+
+  it("renders the entry count in the header", () => {
+    const entries = [BASE_ENTRY, makeEntry({ id: "entry-2", targetLabel: "Orbit NFT" })];
+    render(<AuditLogViewer entries={entries} />);
+
+    expect(screen.getByText(/2 entries/i)).toBeInTheDocument();
+  });
+
+  it("shows 'read-only' label in the header", () => {
+    render(<AuditLogViewer entries={[BASE_ENTRY]} />);
+    expect(screen.getByText(/read-only/i)).toBeInTheDocument();
+  });
+
+  it("renders each entry's target label", () => {
+    const entries = [
+      BASE_ENTRY,
+      makeEntry({ id: "e2", targetLabel: "Stellar Stake", action: "verification_rejected" }),
+    ];
+    render(<AuditLogViewer entries={entries} />);
+
+    expect(screen.getAllByText("Lumina DEX").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Stellar Stake").length).toBeGreaterThan(0);
+  });
+
+  it("displays a human-readable action label instead of the raw key", () => {
+    render(<AuditLogViewer entries={[BASE_ENTRY]} />);
+
+    // "Verification Approved" should appear; "verification_approved" should not
+    expect(screen.getAllByText(/verification approved/i).length).toBeGreaterThan(0);
+    expect(screen.queryByText("verification_approved")).toBeNull();
+  });
+
+  it("renders the reason when provided", () => {
+    const entry = makeEntry({ reason: "Project documents check out" });
+    render(<AuditLogViewer entries={[entry]} />);
+
+    expect(screen.getAllByText("Project documents check out").length).toBeGreaterThan(0);
+  });
+
+  it("renders a dash placeholder when reason is absent", () => {
+    // BASE_ENTRY has no reason
+    render(<AuditLogViewer entries={[BASE_ENTRY]} />);
+    // The em-dash "—" should appear in the table
+    expect(screen.getAllByText("—").length).toBeGreaterThan(0);
+  });
+
+  // ── Action badge colours are applied (smoke test) ──────────────────────────
+
+  it.each([
+    ["verification_approved" as const, /verification approved/i],
+    ["verification_rejected" as const, /verification rejected/i],
+    ["fee_updated" as const, /fee updated/i],
+    ["report_resolved" as const, /report resolved/i],
+    ["report_dismissed" as const, /report dismissed/i],
+  ])("renders readable label for action %s", (action, pattern) => {
+    render(<AuditLogViewer entries={[makeEntry({ id: action, action })]} />);
+    expect(screen.getAllByText(pattern).length).toBeGreaterThan(0);
+  });
+
+  // ── No edit/delete controls ──────────────────────────────────────────────────
+
+  it("renders no edit buttons", () => {
+    render(<AuditLogViewer entries={[BASE_ENTRY]} />);
+    expect(screen.queryByRole("button", { name: /edit/i })).toBeNull();
+  });
+
+  it("renders no delete buttons", () => {
+    render(<AuditLogViewer entries={[BASE_ENTRY]} />);
+    expect(screen.queryByRole("button", { name: /delete/i })).toBeNull();
+    expect(screen.queryByRole("button", { name: /remove/i })).toBeNull();
+  });
+});

--- a/dongle/__tests__/pages/Admin.test.tsx
+++ b/dongle/__tests__/pages/Admin.test.tsx
@@ -85,7 +85,7 @@ describe("Admin Dashboard - Authorization & High Risk Flows", () => {
 
     it("displays verification requests list", () => {
       render(<AdminPage />);
-      expect(screen.getByText(/verification requests/i)).toBeInTheDocument();
+      expect(screen.getAllByText(/verification requests/i).length).toBeGreaterThan(0);
       expect(screen.getByText("Lumina DEX")).toBeInTheDocument();
     });
 
@@ -172,7 +172,7 @@ describe("Admin Dashboard - Authorization & High Risk Flows", () => {
 
     it("renders verification requests section", () => {
       render(<AdminPage />);
-      expect(screen.getByText(/verification requests/i)).toBeInTheDocument();
+      expect(screen.getAllByText(/verification requests/i).length).toBeGreaterThan(0);
     });
 
     it("renders system settings section", () => {

--- a/dongle/__tests__/services/audit-log.service.test.ts
+++ b/dongle/__tests__/services/audit-log.service.test.ts
@@ -1,0 +1,234 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { auditLogService, AUDIT_LOG_STORAGE_KEY } from "@/services/audit/audit-log.service";
+import { setIdGenerator, resetIdGenerator } from "@/lib/id-generator";
+
+// ─── localStorage mock ────────────────────────────────────────────────────────
+const localStorageMock = (() => {
+  let store: Record<string, string> = {};
+  return {
+    getItem: (key: string) => store[key] ?? null,
+    setItem: (key: string, value: string) => { store[key] = value; },
+    removeItem: (key: string) => { delete store[key]; },
+    clear: () => { store = {}; },
+  };
+})();
+
+Object.defineProperty(window, "localStorage", { value: localStorageMock });
+
+// ─── helpers ──────────────────────────────────────────────────────────────────
+let idCounter = 0;
+function nextId() { return `test-id-${++idCounter}`; }
+
+describe("auditLogService", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    idCounter = 0;
+    setIdGenerator(nextId);
+  });
+
+  afterEach(() => {
+    localStorage.clear();
+    resetIdGenerator();
+  });
+
+  // ── append ──────────────────────────────────────────────────────────────────
+
+  describe("append", () => {
+    it("returns an entry with the correct fields", () => {
+      const entry = auditLogService.append({
+        actor: "GADMIN123",
+        action: "verification_approved",
+        targetId: "req_1",
+        targetLabel: "Lumina DEX",
+      });
+
+      expect(entry.id).toBe("test-id-1");
+      expect(entry.actor).toBe("GADMIN123");
+      expect(entry.action).toBe("verification_approved");
+      expect(entry.targetId).toBe("req_1");
+      expect(entry.targetLabel).toBe("Lumina DEX");
+      expect(typeof entry.timestamp).toBe("string");
+      expect(new Date(entry.timestamp).getTime()).not.toBeNaN();
+    });
+
+    it("persists the entry to localStorage", () => {
+      auditLogService.append({
+        actor: "GADMIN123",
+        action: "fee_updated",
+        targetId: "verification_fee",
+        targetLabel: "Verification Fee",
+        metadata: { newValue: 2.5 },
+      });
+
+      const raw = localStorage.getItem(AUDIT_LOG_STORAGE_KEY);
+      expect(raw).not.toBeNull();
+      const parsed = JSON.parse(raw!);
+      expect(parsed).toHaveLength(1);
+      expect(parsed[0].action).toBe("fee_updated");
+      expect(parsed[0].metadata.newValue).toBe(2.5);
+    });
+
+    it("includes reason when provided", () => {
+      const entry = auditLogService.append({
+        actor: "GADMIN123",
+        action: "report_resolved",
+        targetId: "report_42",
+        targetLabel: "Report report_42",
+        reason: "Content violates terms",
+      });
+
+      expect(entry.reason).toBe("Content violates terms");
+    });
+
+    it("omits reason when empty string", () => {
+      const entry = auditLogService.append({
+        actor: "GADMIN123",
+        action: "report_dismissed",
+        targetId: "report_43",
+        targetLabel: "Report report_43",
+        reason: "   ",
+      });
+
+      expect(entry.reason).toBeUndefined();
+    });
+
+    it("accumulates multiple entries", () => {
+      auditLogService.append({ actor: "G1", action: "verification_approved", targetId: "r1", targetLabel: "A" });
+      auditLogService.append({ actor: "G1", action: "verification_rejected", targetId: "r2", targetLabel: "B" });
+      auditLogService.append({ actor: "G2", action: "fee_updated", targetId: "fee", targetLabel: "Fee" });
+
+      expect(auditLogService.count()).toBe(3);
+    });
+  });
+
+  // ── list ────────────────────────────────────────────────────────────────────
+
+  describe("list", () => {
+    beforeEach(() => {
+      auditLogService.append({ actor: "GADMIN1", action: "verification_approved", targetId: "r1", targetLabel: "Lumina DEX" });
+      auditLogService.append({ actor: "GADMIN2", action: "verification_rejected", targetId: "r2", targetLabel: "Stellar Stake" });
+      auditLogService.append({ actor: "GADMIN1", action: "fee_updated", targetId: "fee", targetLabel: "Fee" });
+    });
+
+    it("returns all entries newest-first", () => {
+      const entries = auditLogService.list();
+      expect(entries).toHaveLength(3);
+      // All three actions should be present (order may vary within the same ms)
+      const actions = entries.map((e) => e.action);
+      expect(actions).toContain("verification_approved");
+      expect(actions).toContain("verification_rejected");
+      expect(actions).toContain("fee_updated");
+    });
+
+    it("filters by actor", () => {
+      const entries = auditLogService.list({ actor: "GADMIN1" });
+      expect(entries).toHaveLength(2);
+      entries.forEach((e) => expect(e.actor).toBe("GADMIN1"));
+    });
+
+    it("filters by action", () => {
+      const entries = auditLogService.list({ action: "verification_approved" });
+      expect(entries).toHaveLength(1);
+      expect(entries[0].targetLabel).toBe("Lumina DEX");
+    });
+
+    it("returns empty array when filter matches nothing", () => {
+      const entries = auditLogService.list({ actor: "GNOTHERE" });
+      expect(entries).toHaveLength(0);
+    });
+
+    it("returns empty array when storage is empty", () => {
+      auditLogService._clearForTesting();
+      expect(auditLogService.list()).toHaveLength(0);
+    });
+  });
+
+  // ── getById ─────────────────────────────────────────────────────────────────
+
+  describe("getById", () => {
+    it("returns the correct entry by id", () => {
+      const created = auditLogService.append({
+        actor: "GADMIN1",
+        action: "report_resolved",
+        targetId: "rep_1",
+        targetLabel: "Report rep_1",
+      });
+
+      const found = auditLogService.getById(created.id);
+      expect(found).not.toBeNull();
+      expect(found!.id).toBe(created.id);
+      expect(found!.action).toBe("report_resolved");
+    });
+
+    it("returns null for unknown id", () => {
+      expect(auditLogService.getById("does-not-exist")).toBeNull();
+    });
+  });
+
+  // ── count ───────────────────────────────────────────────────────────────────
+
+  describe("count", () => {
+    it("returns 0 when storage is empty", () => {
+      expect(auditLogService.count()).toBe(0);
+    });
+
+    it("increments after each append", () => {
+      auditLogService.append({ actor: "G1", action: "fee_updated", targetId: "f", targetLabel: "Fee" });
+      expect(auditLogService.count()).toBe(1);
+      auditLogService.append({ actor: "G1", action: "verification_approved", targetId: "r", targetLabel: "X" });
+      expect(auditLogService.count()).toBe(2);
+    });
+  });
+
+  // ── resilience ──────────────────────────────────────────────────────────────
+
+  describe("resilience", () => {
+    it("returns empty array for corrupt localStorage data", () => {
+      localStorage.setItem(AUDIT_LOG_STORAGE_KEY, "not-valid-json{{{");
+      expect(auditLogService.list()).toHaveLength(0);
+    });
+
+    it("skips partial/invalid records but keeps valid ones", () => {
+      const valid = {
+        id: "good-id",
+        actor: "GADMIN",
+        action: "fee_updated",
+        targetId: "fee",
+        targetLabel: "Fee",
+        timestamp: new Date().toISOString(),
+      };
+      const corrupt = { id: "", actor: "X" }; // missing required fields
+      localStorage.setItem(AUDIT_LOG_STORAGE_KEY, JSON.stringify([corrupt, valid]));
+
+      const entries = auditLogService.list();
+      expect(entries).toHaveLength(1);
+      expect(entries[0].id).toBe("good-id");
+    });
+
+    it("rejects entries with unknown action values", () => {
+      const entry = {
+        id: "e1",
+        actor: "GADMIN",
+        action: "unknown_action",
+        targetId: "x",
+        targetLabel: "X",
+        timestamp: new Date().toISOString(),
+      };
+      localStorage.setItem(AUDIT_LOG_STORAGE_KEY, JSON.stringify([entry]));
+      expect(auditLogService.list()).toHaveLength(0);
+    });
+  });
+
+  // ── _clearForTesting ────────────────────────────────────────────────────────
+
+  describe("_clearForTesting", () => {
+    it("removes all entries from storage", () => {
+      auditLogService.append({ actor: "G1", action: "fee_updated", targetId: "f", targetLabel: "Fee" });
+      expect(auditLogService.count()).toBe(1);
+
+      auditLogService._clearForTesting();
+      expect(auditLogService.count()).toBe(0);
+      expect(localStorage.getItem(AUDIT_LOG_STORAGE_KEY)).toBeNull();
+    });
+  });
+});

--- a/dongle/app/admin/page.tsx
+++ b/dongle/app/admin/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useMemo, useEffect } from "react";
+import { useState, useEffect } from "react";
 import { toast } from "sonner";
 import AddressDisplay from "@/components/ui/AddressDisplay";
 import WalletStatePanel, {
@@ -8,10 +8,12 @@ import WalletStatePanel, {
 } from "@/components/wallet/WalletStatePanel";
 import { useAdminAccess } from "@/hooks/useAdminAccess";
 import { formatDate } from "@/lib/date";
-import { AlertCircle, Flag, Shield, CheckCircle, XCircle, Clock, MessageSquare } from "lucide-react";
+import { AlertCircle, Flag, Shield, CheckCircle, XCircle, Clock, MessageSquare, ScrollText } from "lucide-react";
 import { reviewReportService } from "@/services/review/review-report.service";
 import { reviewService } from "@/services/review/review.service";
+import { auditLogService } from "@/services/audit/audit-log.service";
 import { ReviewReport, ModerationAction, Review } from "@/types/review";
+import AuditLogViewer from "@/components/admin/AuditLogViewer";
 
 interface VerificationRequest {
   id: string;
@@ -34,19 +36,11 @@ export default function AdminDashboard() {
   const { isAdmin, isAdminChecking, gate } = useAdminAccess();
   const [requests, setRequests] = useState<VerificationRequest[]>(MOCK_REQUESTS);
   const [fee, setFee] = useState(1.5);
-  const [activeTab, setActiveTab] = useState<"verification" | "reports">("verification");
+  const [activeTab, setActiveTab] = useState<"verification" | "reports" | "audit-log">("verification");
   const [reports, setReports] = useState<ReviewReport[]>([]);
   const [moderationLog, setModerationLog] = useState<ModerationAction[]>([]);
   const [moderationReason, setModerationReason] = useState<Record<string, string>>({});
   const [expandedReport, setExpandedReport] = useState<string | null>(null);
-
-  const isAdmin = useMemo(
-    () =>
-      gate.state === "ready" &&
-      Boolean(gate.publicKey) &&
-      ADMIN_ALLOWLIST.includes(gate.publicKey!),
-    [gate.state, gate.publicKey],
-  );
 
   // Load reports and moderation log
   useEffect(() => {
@@ -57,12 +51,30 @@ export default function AdminDashboard() {
   }, [isAdmin]);
 
   const handleAction = (id: string, status: "approved" | "rejected") => {
+    const req = requests.find((r) => r.id === id);
     setRequests((prev) =>
-      prev.map((req) => (req.id === id ? { ...req, status } : req)),
+      prev.map((r) => (r.id === id ? { ...r, status } : r)),
     );
+    if (req && gate.publicKey) {
+      auditLogService.append({
+        actor: gate.publicKey,
+        action: status === "approved" ? "verification_approved" : "verification_rejected",
+        targetId: req.id,
+        targetLabel: req.projectName,
+      });
+    }
   };
 
   const handleSaveFee = () => {
+    if (gate.publicKey) {
+      auditLogService.append({
+        actor: gate.publicKey,
+        action: "fee_updated",
+        targetId: "verification_fee",
+        targetLabel: "Verification Fee",
+        metadata: { newValue: fee },
+      });
+    }
     toast.success(`Verification fee updated to ${fee} XLM`);
   };
 
@@ -72,6 +84,13 @@ export default function AdminDashboard() {
 
     const result = reviewReportService.resolveReport(reportId, gate.publicKey, reason);
     if (result.success) {
+      auditLogService.append({
+        actor: gate.publicKey,
+        action: "report_resolved",
+        targetId: reportId,
+        targetLabel: `Report ${reportId}`,
+        reason,
+      });
       toast.success("Report resolved successfully");
       setReports(reviewReportService.getReports());
       setModerationLog(reviewReportService.getModerationLog());
@@ -87,6 +106,13 @@ export default function AdminDashboard() {
 
     const result = reviewReportService.dismissReport(reportId, gate.publicKey, reason);
     if (result.success) {
+      auditLogService.append({
+        actor: gate.publicKey,
+        action: "report_dismissed",
+        targetId: reportId,
+        targetLabel: `Report ${reportId}`,
+        reason,
+      });
       toast.success("Report dismissed");
       setReports(reviewReportService.getReports());
       setModerationLog(reviewReportService.getModerationLog());
@@ -146,15 +172,6 @@ export default function AdminDashboard() {
   }
 
   // ── 3. Authorized — render dashboard ────────────────────────────────────────
-  const handleAction = (id: string, status: "approved" | "rejected") => {
-    setRequests((prev) =>
-      prev.map((req) => (req.id === id ? { ...req, status } : req)),
-    );
-  };
-
-  const handleSaveFee = () => {
-    toast.success(`Verification fee updated to ${fee} XLM`);
-  };
 
   return (
     <div className="container mx-auto px-4 py-12">
@@ -197,6 +214,20 @@ export default function AdminDashboard() {
               </span>
             )}
             {activeTab === "reports" && (
+              <div className="absolute bottom-0 left-0 right-0 h-0.5 bg-blue-600 dark:bg-blue-400" />
+            )}
+          </button>
+          <button
+            onClick={() => setActiveTab("audit-log")}
+            className={`pb-3 px-1 font-medium transition-colors relative flex items-center gap-2 ${
+              activeTab === "audit-log"
+                ? "text-blue-600 dark:text-blue-400"
+                : "text-zinc-500 dark:text-zinc-400 hover:text-zinc-900 dark:hover:text-zinc-100"
+            }`}
+          >
+            <ScrollText className="w-4 h-4" />
+            Audit Log
+            {activeTab === "audit-log" && (
               <div className="absolute bottom-0 left-0 right-0 h-0.5 bg-blue-600 dark:bg-blue-400" />
             )}
           </button>
@@ -556,6 +587,9 @@ export default function AdminDashboard() {
               </div>
             </div>
           </div>
+        )}
+        {activeTab === "audit-log" && (
+          <AuditLogViewer entries={auditLogService.list()} />
         )}
       </div>
     </div>

--- a/dongle/components/admin/AuditLogViewer.tsx
+++ b/dongle/components/admin/AuditLogViewer.tsx
@@ -1,0 +1,154 @@
+"use client";
+
+/**
+ * AuditLogViewer
+ *
+ * Read-only table that lists all admin audit log entries.
+ * No edit or delete controls are rendered — this panel is intentionally
+ * display-only to satisfy the acceptance criterion that logs cannot be
+ * edited from the regular admin UI.
+ */
+
+import { AuditLogEntry, AUDIT_ACTION_LABELS } from "@/types/audit-log";
+import { formatDate } from "@/lib/date";
+import AddressDisplay from "@/components/ui/AddressDisplay";
+import { ScrollText } from "lucide-react";
+
+interface AuditLogViewerProps {
+  entries: AuditLogEntry[];
+}
+
+/** Badge colour keyed by action. */
+function actionClass(action: AuditLogEntry["action"]): string {
+  switch (action) {
+    case "verification_approved":
+      return "bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400";
+    case "verification_rejected":
+      return "bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-400";
+    case "fee_updated":
+      return "bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-400";
+    case "report_resolved":
+      return "bg-teal-100 text-teal-700 dark:bg-teal-900/30 dark:text-teal-400";
+    case "report_dismissed":
+      return "bg-zinc-100 text-zinc-600 dark:bg-zinc-800 dark:text-zinc-400";
+    default:
+      return "bg-zinc-100 text-zinc-600 dark:bg-zinc-800 dark:text-zinc-400";
+  }
+}
+
+export default function AuditLogViewer({ entries }: AuditLogViewerProps) {
+  if (entries.length === 0) {
+    return (
+      <div className="text-center py-20 bg-white dark:bg-zinc-900 border border-zinc-200 dark:border-zinc-800 rounded-3xl">
+        <ScrollText className="w-12 h-12 text-zinc-300 dark:text-zinc-600 mx-auto mb-4" />
+        <p className="font-medium text-zinc-500 dark:text-zinc-400">No audit log entries yet</p>
+        <p className="text-sm text-zinc-400 dark:text-zinc-500 mt-1">
+          Admin actions will appear here once they are performed.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center justify-between">
+        <h2 className="text-xl font-bold flex items-center gap-2">
+          <span className="w-2 h-8 bg-violet-500 rounded-full" />
+          Audit Log
+        </h2>
+        <span className="text-sm text-zinc-500 dark:text-zinc-400">
+          {entries.length} {entries.length === 1 ? "entry" : "entries"} — read-only
+        </span>
+      </div>
+
+      {/* Desktop table */}
+      <div className="hidden md:block overflow-x-auto rounded-3xl border border-zinc-200 dark:border-zinc-800">
+        <table className="w-full text-sm">
+          <thead>
+            <tr className="bg-zinc-50 dark:bg-zinc-900 border-b border-zinc-200 dark:border-zinc-800">
+              <th className="text-left px-6 py-3 font-semibold text-zinc-500 dark:text-zinc-400 uppercase text-xs tracking-wider">
+                Timestamp
+              </th>
+              <th className="text-left px-6 py-3 font-semibold text-zinc-500 dark:text-zinc-400 uppercase text-xs tracking-wider">
+                Actor
+              </th>
+              <th className="text-left px-6 py-3 font-semibold text-zinc-500 dark:text-zinc-400 uppercase text-xs tracking-wider">
+                Action
+              </th>
+              <th className="text-left px-6 py-3 font-semibold text-zinc-500 dark:text-zinc-400 uppercase text-xs tracking-wider">
+                Target
+              </th>
+              <th className="text-left px-6 py-3 font-semibold text-zinc-500 dark:text-zinc-400 uppercase text-xs tracking-wider">
+                Reason
+              </th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-zinc-100 dark:divide-zinc-800 bg-white dark:bg-zinc-900">
+            {entries.map((entry) => (
+              <tr
+                key={entry.id}
+                className="hover:bg-zinc-50 dark:hover:bg-zinc-800/50 transition-colors"
+              >
+                <td className="px-6 py-4 whitespace-nowrap text-zinc-500 dark:text-zinc-400 font-mono text-xs">
+                  {formatDate(entry.timestamp, "short")}
+                </td>
+                <td className="px-6 py-4 whitespace-nowrap font-mono text-xs">
+                  <AddressDisplay
+                    address={entry.actor}
+                    copyable
+                    truncated
+                    inline
+                  />
+                </td>
+                <td className="px-6 py-4 whitespace-nowrap">
+                  <span
+                    className={`text-[10px] uppercase font-bold px-2 py-1 rounded-full ${actionClass(entry.action)}`}
+                  >
+                    {AUDIT_ACTION_LABELS[entry.action]}
+                  </span>
+                </td>
+                <td className="px-6 py-4 text-zinc-700 dark:text-zinc-300">
+                  {entry.targetLabel}
+                </td>
+                <td className="px-6 py-4 text-zinc-500 dark:text-zinc-400 max-w-xs truncate">
+                  {entry.reason ?? <span className="text-zinc-300 dark:text-zinc-600">—</span>}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+
+      {/* Mobile card list */}
+      <div className="md:hidden space-y-3">
+        {entries.map((entry) => (
+          <div
+            key={entry.id}
+            className="bg-white dark:bg-zinc-900 border border-zinc-200 dark:border-zinc-800 p-4 rounded-2xl space-y-2"
+          >
+            <div className="flex items-center justify-between">
+              <span
+                className={`text-[10px] uppercase font-bold px-2 py-1 rounded-full ${actionClass(entry.action)}`}
+              >
+                {AUDIT_ACTION_LABELS[entry.action]}
+              </span>
+              <span className="text-xs text-zinc-400 font-mono">
+                {formatDate(entry.timestamp, "short")}
+              </span>
+            </div>
+            <div className="text-sm font-medium">{entry.targetLabel}</div>
+            <div className="text-xs text-zinc-500 dark:text-zinc-400">
+              Actor:{" "}
+              <AddressDisplay address={entry.actor} copyable truncated inline />
+            </div>
+            {entry.reason && (
+              <div className="text-xs text-zinc-500 dark:text-zinc-400">
+                Reason: {entry.reason}
+              </div>
+            )}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/dongle/services/audit/audit-log.service.ts
+++ b/dongle/services/audit/audit-log.service.ts
@@ -1,0 +1,183 @@
+/**
+ * Audit Log Service
+ *
+ * Appends an immutable record for every admin mutation and provides read-only
+ * accessors for the admin dashboard.  All data is persisted to localStorage
+ * (same pattern as review-report.service.ts and draft.service.ts).
+ *
+ * Rules enforced here:
+ * - append() is the only write path; no update/delete methods are exposed.
+ * - list() / getById() are read-only.
+ * - Corrupt or partial records are skipped during hydration (never throw).
+ */
+
+import {
+  AuditLogEntry,
+  AuditAction,
+  AppendAuditLogParams,
+  AuditLogFilter,
+} from "@/types/audit-log";
+import { generateId } from "@/lib/id-generator";
+
+export const AUDIT_LOG_STORAGE_KEY = "dongle_audit_log";
+
+const VALID_ACTIONS: ReadonlySet<AuditAction> = new Set<AuditAction>([
+  "verification_approved",
+  "verification_rejected",
+  "fee_updated",
+  "report_resolved",
+  "report_dismissed",
+]);
+
+/** Hydrate, validate, and return all stored entries (SSR-safe). */
+function loadEntries(): AuditLogEntry[] {
+  if (typeof window === "undefined") return [];
+
+  let raw: string | null;
+  try {
+    raw = localStorage.getItem(AUDIT_LOG_STORAGE_KEY);
+  } catch {
+    return [];
+  }
+  if (!raw) return [];
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return [];
+  }
+
+  if (!Array.isArray(parsed)) return [];
+
+  const valid: AuditLogEntry[] = [];
+  for (const item of parsed) {
+    if (!item || typeof item !== "object") continue;
+    const r = item as Record<string, unknown>;
+
+    if (typeof r.id !== "string" || !r.id) continue;
+    if (typeof r.actor !== "string" || !r.actor) continue;
+    if (typeof r.action !== "string" || !VALID_ACTIONS.has(r.action as AuditAction)) continue;
+    if (typeof r.targetId !== "string" || !r.targetId) continue;
+    if (typeof r.targetLabel !== "string") continue;
+    if (typeof r.timestamp !== "string" || !r.timestamp) continue;
+
+    const entry: AuditLogEntry = {
+      id: r.id,
+      actor: r.actor,
+      action: r.action as AuditAction,
+      targetId: r.targetId,
+      targetLabel: r.targetLabel,
+      timestamp: r.timestamp,
+    };
+
+    if (typeof r.reason === "string" && r.reason) {
+      entry.reason = r.reason;
+    }
+
+    if (r.metadata && typeof r.metadata === "object" && !Array.isArray(r.metadata)) {
+      entry.metadata = r.metadata as Record<string, string | number | boolean>;
+    }
+
+    valid.push(entry);
+  }
+
+  return valid;
+}
+
+/** Persist the full entry list. */
+function saveEntries(entries: AuditLogEntry[]): void {
+  if (typeof window === "undefined") return;
+  try {
+    localStorage.setItem(AUDIT_LOG_STORAGE_KEY, JSON.stringify(entries));
+  } catch {
+    // Storage quota exceeded or private browsing — fail silently
+  }
+}
+
+export const auditLogService = {
+  // ── Write ────────────────────────────────────────────────────────────────
+
+  /**
+   * Append a new audit log entry.
+   * This is the ONLY write path; entries are never modified or deleted.
+   * Returns the created entry.
+   */
+  append(params: AppendAuditLogParams): AuditLogEntry {
+    const entry: AuditLogEntry = {
+      id: generateId(),
+      actor: params.actor,
+      action: params.action,
+      targetId: params.targetId,
+      targetLabel: params.targetLabel,
+      timestamp: new Date().toISOString(),
+    };
+
+    if (params.reason?.trim()) {
+      entry.reason = params.reason.trim();
+    }
+
+    if (params.metadata && Object.keys(params.metadata).length > 0) {
+      entry.metadata = { ...params.metadata };
+    }
+
+    const entries = loadEntries();
+    saveEntries([...entries, entry]);
+    return entry;
+  },
+
+  // ── Read ─────────────────────────────────────────────────────────────────
+
+  /**
+   * Return all entries, newest-first, optionally filtered.
+   */
+  list(filter?: AuditLogFilter): AuditLogEntry[] {
+    let entries = loadEntries();
+
+    if (filter?.actor) {
+      entries = entries.filter((e) => e.actor === filter.actor);
+    }
+    if (filter?.action) {
+      entries = entries.filter((e) => e.action === filter.action);
+    }
+    if (filter?.since) {
+      const since = new Date(filter.since).getTime();
+      entries = entries.filter((e) => new Date(e.timestamp).getTime() >= since);
+    }
+    if (filter?.until) {
+      const until = new Date(filter.until).getTime();
+      entries = entries.filter((e) => new Date(e.timestamp).getTime() <= until);
+    }
+
+    // Newest first
+    return entries.sort(
+      (a, b) => new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime(),
+    );
+  },
+
+  /** Return a single entry by ID, or null if not found. */
+  getById(id: string): AuditLogEntry | null {
+    return loadEntries().find((e) => e.id === id) ?? null;
+  },
+
+  /** Total count of stored entries (unfiltered). */
+  count(): number {
+    return loadEntries().length;
+  },
+
+  // ── Test helpers ─────────────────────────────────────────────────────────
+
+  /**
+   * Wipe all entries from storage.
+   * Only intended for use in test environments.
+   */
+  _clearForTesting(): void {
+    if (typeof window !== "undefined") {
+      try {
+        localStorage.removeItem(AUDIT_LOG_STORAGE_KEY);
+      } catch {
+        // ignore
+      }
+    }
+  },
+};

--- a/dongle/types/audit-log.ts
+++ b/dongle/types/audit-log.ts
@@ -1,0 +1,63 @@
+/**
+ * Audit Log Types
+ *
+ * Every admin mutation must produce an AuditLogEntry so that all admin actions
+ * are traceable, immutable from the regular UI, and visible in the Audit Log tab.
+ */
+
+/** The set of admin actions that are recorded. */
+export type AuditAction =
+  | "verification_approved"
+  | "verification_rejected"
+  | "fee_updated"
+  | "report_resolved"
+  | "report_dismissed";
+
+/** Human-readable labels for each action. */
+export const AUDIT_ACTION_LABELS: Record<AuditAction, string> = {
+  verification_approved: "Verification Approved",
+  verification_rejected: "Verification Rejected",
+  fee_updated: "Fee Updated",
+  report_resolved: "Report Resolved",
+  report_dismissed: "Report Dismissed",
+};
+
+/**
+ * A single immutable audit log entry.
+ *
+ * - `actor`     – Stellar G… public key of the admin who performed the action.
+ * - `action`    – One of the fixed AuditAction values.
+ * - `targetId`  – Identifier of the entity that was acted on (request ID, report ID, …).
+ * - `targetLabel` – Human-readable name/label for the target (project name, etc.).
+ * - `timestamp` – ISO 8601 string; set at write time and never altered.
+ * - `reason`    – Optional free-text reason the admin supplied.
+ * - `metadata`  – Optional key/value bag for additional context (old value, new value, …).
+ */
+export interface AuditLogEntry {
+  id: string;
+  actor: string;
+  action: AuditAction;
+  targetId: string;
+  targetLabel: string;
+  timestamp: string;
+  reason?: string;
+  metadata?: Record<string, string | number | boolean>;
+}
+
+/** Parameters accepted by auditLogService.append(). */
+export interface AppendAuditLogParams {
+  actor: string;
+  action: AuditAction;
+  targetId: string;
+  targetLabel: string;
+  reason?: string;
+  metadata?: Record<string, string | number | boolean>;
+}
+
+/** Filter options for auditLogService.list(). */
+export interface AuditLogFilter {
+  actor?: string;
+  action?: AuditAction;
+  since?: string; // ISO 8601 – return entries on or after this date
+  until?: string; // ISO 8601 – return entries on or before this date
+}


### PR DESCRIPTION
- Add AuditLogEntry type with actor, action, target, timestamp, reason, metadata fields
- Create auditLogService with append (write-once), list, getById, count, filter support
- Integrate audit log calls into every admin mutation: approve/reject verification, update fee, resolve/dismiss report
- Add AuditLogViewer component (read-only table + mobile card list)
- Add Audit Log tab to admin dashboard wired to auditLogService
- Fix duplicate isAdmin/handleAction/handleSaveFee declarations in admin page
- Add tests for auditLogService (18 cases) and AuditLogViewer (13 cases)
- Fix Admin.test.tsx assertions broken by new tab adding a second 'Verification Requests' element

closes #257