### PR TITLE
Add bulk admin actions for queues (#259)

### DIFF
--- a/dongle/__tests__/pages/Admin.test.tsx
+++ b/dongle/__tests__/pages/Admin.test.tsx
@@ -85,7 +85,7 @@ describe("Admin Dashboard - Authorization & High Risk Flows", () => {
 
     it("displays verification requests list", () => {
       render(<AdminPage />);
-      expect(screen.getByText(/verification requests/i)).toBeInTheDocument();
+      expect(screen.getAllByText(/verification requests/i).length).toBeGreaterThan(0);
       expect(screen.getByText("Lumina DEX")).toBeInTheDocument();
     });
 
@@ -172,7 +172,7 @@ describe("Admin Dashboard - Authorization & High Risk Flows", () => {
 
     it("renders verification requests section", () => {
       render(<AdminPage />);
-      expect(screen.getByText(/verification requests/i)).toBeInTheDocument();
+      expect(screen.getAllByText(/verification requests/i).length).toBeGreaterThan(0);
     });
 
     it("renders system settings section", () => {

--- a/dongle/app/admin/page.tsx
+++ b/dongle/app/admin/page.tsx
@@ -1,24 +1,38 @@
 "use client";
 
-import { useState, useMemo, useEffect } from "react";
+import { useState, useEffect, useCallback } from "react";
 import { toast } from "sonner";
 import AddressDisplay from "@/components/ui/AddressDisplay";
 import WalletStatePanel, {
   WalletStateLoadingPanel,
 } from "@/components/wallet/WalletStatePanel";
 import { useAdminAccess } from "@/hooks/useAdminAccess";
+import { useConfirm } from "@/hooks/useConfirm";
 import { formatDate } from "@/lib/date";
-import { AlertCircle, Flag, Shield, CheckCircle, XCircle, Clock, MessageSquare } from "lucide-react";
+import {
+  AlertCircle, Flag, Shield, CheckCircle, XCircle, Clock, MessageSquare,
+  CheckCheck, Archive, UserPlus, X,
+} from "lucide-react";
 import { reviewReportService } from "@/services/review/review-report.service";
 import { reviewService } from "@/services/review/review.service";
 import { ReviewReport, ModerationAction, Review } from "@/types/review";
+
+type RequestStatus = "pending" | "approved" | "rejected" | "archived";
 
 interface VerificationRequest {
   id: string;
   projectName: string;
   submittedBy: string;
-  status: "pending" | "approved" | "rejected";
+  status: RequestStatus;
   timestamp: string;
+}
+
+type BulkAction = "approve" | "reject" | "archive" | "assign";
+
+interface BulkActionResult {
+  action: BulkAction;
+  succeeded: string[];
+  failed: { id: string; reason: string }[];
 }
 
 const MOCK_REQUESTS: VerificationRequest[] = [
@@ -30,8 +44,87 @@ const MOCK_REQUESTS: VerificationRequest[] = [
 const ADMIN_PURPOSE =
   "Connect an authorized admin Freighter wallet to manage verification requests, review reports, and system settings.";
 
+const STATUS_STYLES: Record<RequestStatus, string> = {
+  pending: "bg-yellow-100 text-yellow-700 dark:bg-yellow-900/30 dark:text-yellow-500",
+  approved: "bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-500",
+  rejected: "bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-500",
+  archived: "bg-zinc-100 text-zinc-500 dark:bg-zinc-800/50 dark:text-zinc-400",
+};
+
+const BULK_ACTION_CONFIG: Record<BulkAction, { label: string; icon: React.ReactNode; confirmTitle: string; confirmDescription: (count: number) => string }> = {
+  approve: {
+    label: "Approve Selected",
+    icon: <CheckCheck className="w-4 h-4" />,
+    confirmTitle: "Approve requests?",
+    confirmDescription: (count) => `Are you sure you want to approve ${count} verification request${count !== 1 ? "s" : ""}? This will mark them as verified.`,
+  },
+  reject: {
+    label: "Reject Selected",
+    icon: <X className="w-4 h-4" />,
+    confirmTitle: "Reject requests?",
+    confirmDescription: (count) => `Are you sure you want to reject ${count} verification request${count !== 1 ? "s" : ""}? The submitters will be notified.`,
+  },
+  archive: {
+    label: "Archive Selected",
+    icon: <Archive className="w-4 h-4" />,
+    confirmTitle: "Archive requests?",
+    confirmDescription: (count) => `Are you sure you want to archive ${count} verification request${count !== 1 ? "s" : ""}? Archived items are hidden from the active queue.`,
+  },
+  assign: {
+    label: "Assign to Me",
+    icon: <UserPlus className="w-4 h-4" />,
+    confirmTitle: "Assign requests?",
+    confirmDescription: (count) => `Are you sure you want to assign ${count} verification request${count !== 1 ? "s" : ""} to yourself?`,
+  },
+};
+
+function BulkFailureDetail({ result }: { result: BulkActionResult }) {
+  if (result.failed.length === 0) return null;
+
+  return (
+    <div className="mt-2 text-xs">
+      <p className="font-medium mb-1">Failed ({result.failed.length}):</p>
+      <ul className="list-disc list-inside space-y-0.5 text-zinc-500">
+        {result.failed.map((f) => (
+          <li key={f.id}>
+            <span className="font-mono">{f.id}</span>: {f.reason}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+function reportBulkActionResult(result: BulkActionResult) {
+  const actionLabel = BULK_ACTION_CONFIG[result.action].label;
+  if (result.succeeded.length > 0 && result.failed.length === 0) {
+    toast.success(`${actionLabel}: ${result.succeeded.length} succeeded`, {
+      description: `All ${result.succeeded.length} request${result.succeeded.length !== 1 ? "s" : ""} processed successfully.`,
+    });
+  } else if (result.succeeded.length > 0 && result.failed.length > 0) {
+    toast.warning(`${actionLabel}: ${result.succeeded.length} succeeded, ${result.failed.length} failed`, {
+      description: "Some requests could not be processed.",
+      duration: 8000,
+    });
+    toast.error(`Partial failure details`, {
+      description: <BulkFailureDetail result={result} />,
+      duration: 10000,
+    });
+  } else {
+    toast.error(`${actionLabel}: All ${result.failed.length} failed`, {
+      description: "None of the selected requests could be processed.",
+      duration: 8000,
+    });
+    toast.error(`Failure details`, {
+      description: <BulkFailureDetail result={result} />,
+      duration: 10000,
+    });
+  }
+}
+
 export default function AdminDashboard() {
   const { isAdmin, isAdminChecking, gate } = useAdminAccess();
+  const confirm = useConfirm();
   const [requests, setRequests] = useState<VerificationRequest[]>(MOCK_REQUESTS);
   const [fee, setFee] = useState(1.5);
   const [activeTab, setActiveTab] = useState<"verification" | "reports">("verification");
@@ -39,14 +132,8 @@ export default function AdminDashboard() {
   const [moderationLog, setModerationLog] = useState<ModerationAction[]>([]);
   const [moderationReason, setModerationReason] = useState<Record<string, string>>({});
   const [expandedReport, setExpandedReport] = useState<string | null>(null);
-
-  const isAdmin = useMemo(
-    () =>
-      gate.state === "ready" &&
-      Boolean(gate.publicKey) &&
-      ADMIN_ALLOWLIST.includes(gate.publicKey!),
-    [gate.state, gate.publicKey],
-  );
+  const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
+  const [isBulkProcessing, setIsBulkProcessing] = useState(false);
 
   // Load reports and moderation log
   useEffect(() => {
@@ -61,6 +148,98 @@ export default function AdminDashboard() {
       prev.map((req) => (req.id === id ? { ...req, status } : req)),
     );
   };
+
+  const toggleSelection = useCallback((id: string) => {
+    setSelectedIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) {
+        next.delete(id);
+      } else {
+        next.add(id);
+      }
+      return next;
+    });
+  }, []);
+
+  const toggleSelectAll = useCallback(() => {
+    setSelectedIds((prev) => {
+      const allSelectable = requests
+        .filter((r) => r.status === "pending")
+        .map((r) => r.id);
+      if (allSelectable.every((id) => prev.has(id))) {
+        return new Set();
+      }
+      return new Set(allSelectable);
+    });
+  }, [requests]);
+
+  const clearSelection = useCallback(() => {
+    setSelectedIds(new Set());
+  }, []);
+
+  const handleBulkAction = useCallback(async (action: BulkAction) => {
+    const config = BULK_ACTION_CONFIG[action];
+    const count = selectedIds.size;
+
+    if (count === 0) return;
+
+    const confirmed = await confirm({
+      title: config.confirmTitle,
+      description: config.confirmDescription(count),
+      variant: action === "reject" ? "danger" : "warning",
+      confirmLabel: action === "approve" ? "Approve All"
+        : action === "reject" ? "Reject All"
+        : action === "archive" ? "Archive All"
+        : "Assign All",
+    });
+
+    if (!confirmed) return;
+
+    setIsBulkProcessing(true);
+
+    const succeeded: string[] = [];
+    const failed: { id: string; reason: string }[] = [];
+
+    setRequests((prev) => {
+      const updated = prev.map((req) => {
+        if (!selectedIds.has(req.id)) return req;
+
+        if (req.status !== "pending") {
+          failed.push({ id: req.id, reason: `Cannot ${action} request with status "${req.status}"` });
+          return req;
+        }
+
+        let newStatus: RequestStatus;
+        switch (action) {
+          case "approve":
+            newStatus = "approved";
+            break;
+          case "reject":
+            newStatus = "rejected";
+            break;
+          case "archive":
+            newStatus = "archived";
+            break;
+          case "assign":
+            newStatus = req.status;
+            break;
+          default:
+            return req;
+        }
+
+        succeeded.push(req.id);
+        return { ...req, status: newStatus };
+      });
+
+      return updated;
+    });
+
+    setTimeout(() => {
+      setIsBulkProcessing(false);
+      setSelectedIds(new Set());
+      reportBulkActionResult({ action, succeeded, failed });
+    }, 0);
+  }, [selectedIds, confirm]);
 
   const handleSaveFee = () => {
     toast.success(`Verification fee updated to ${fee} XLM`);
@@ -146,16 +325,6 @@ export default function AdminDashboard() {
   }
 
   // ── 3. Authorized — render dashboard ────────────────────────────────────────
-  const handleAction = (id: string, status: "approved" | "rejected") => {
-    setRequests((prev) =>
-      prev.map((req) => (req.id === id ? { ...req, status } : req)),
-    );
-  };
-
-  const handleSaveFee = () => {
-    toast.success(`Verification fee updated to ${fee} XLM`);
-  };
-
   return (
     <div className="container mx-auto px-4 py-12">
       <div className="max-w-6xl mx-auto">
@@ -205,58 +374,108 @@ export default function AdminDashboard() {
         {activeTab === "verification" && (
           <div className="grid grid-cols-1 lg:grid-cols-3 gap-8">
             <div className="lg:col-span-2 space-y-6">
-              <h2 className="text-xl font-bold flex items-center gap-2">
-                <span className="w-2 h-8 bg-purple-500 rounded-full" />
-                Verification Requests
-              </h2>
+              <div className="flex items-center justify-between">
+                <h2 className="text-xl font-bold flex items-center gap-2">
+                  <span className="w-2 h-8 bg-purple-500 rounded-full" />
+                  Verification Requests
+                </h2>
+                {selectedIds.size > 0 && (
+                  <button
+                    onClick={clearSelection}
+                    className="text-xs text-zinc-500 hover:text-zinc-900 dark:hover:text-zinc-100 transition-colors"
+                  >
+                    Clear selection ({selectedIds.size})
+                  </button>
+                )}
+              </div>
+
+              {/* Select-all toggle */}
+              {requests.some((r) => r.status === "pending") && (
+                <div className="flex items-center gap-3 px-1">
+                  <label className="flex items-center gap-2 cursor-pointer group">
+                    <input
+                      type="checkbox"
+                      checked={
+                        requests.filter((r) => r.status === "pending").length > 0 &&
+                        requests.filter((r) => r.status === "pending").every((r) => selectedIds.has(r.id))
+                      }
+                      onChange={toggleSelectAll}
+                      className="w-4 h-4 rounded border-zinc-300 dark:border-zinc-700 text-purple-500 focus:ring-purple-500 cursor-pointer"
+                      aria-label="Select all pending requests"
+                    />
+                    <span className="text-xs text-zinc-500 group-hover:text-zinc-700 dark:group-hover:text-zinc-300 transition-colors">
+                      {requests.filter((r) => r.status === "pending").every((r) => selectedIds.has(r.id))
+                        ? "Deselect all"
+                        : "Select all pending"}
+                    </span>
+                  </label>
+                </div>
+              )}
 
               <div className="space-y-4">
-                {requests.map((req) => (
-                  <div
-                    key={req.id}
-                    className="bg-white dark:bg-zinc-900 border border-zinc-200 dark:border-zinc-800 p-6 rounded-3xl flex flex-col md:flex-row justify-between items-start md:items-center gap-4 transition-all hover:shadow-lg"
-                  >
-                    <div>
-                      <h3 className="font-bold text-lg mb-1">{req.projectName}</h3>
-                      <div className="text-xs text-zinc-500 font-mono flex items-center gap-1.5 flex-wrap">
-                        <span>Submitted by:</span>
-                        <AddressDisplay address={req.submittedBy} copyable={true} truncated={true} inline={true} />
-                        <span className="text-zinc-300 dark:text-zinc-700">•</span>
-                        <span>{formatDate(req.timestamp, "short")}</span>
-                      </div>
-                      <div className="mt-2">
-                        <span
-                          className={`text-[10px] uppercase font-bold px-2 py-1 rounded-full ${
-                            req.status === "pending"
-                              ? "bg-yellow-100 text-yellow-700 dark:bg-yellow-900/30 dark:text-yellow-500"
-                              : req.status === "approved"
-                                ? "bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-500"
-                                : "bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-500"
-                          }`}
-                        >
-                          {req.status}
-                        </span>
-                      </div>
-                    </div>
+                {requests.map((req) => {
+                  const isPending = req.status === "pending";
+                  return (
+                    <div
+                      key={req.id}
+                      className={`bg-white dark:bg-zinc-900 border p-6 rounded-3xl flex flex-col md:flex-row justify-between items-start md:items-center gap-4 transition-all hover:shadow-lg ${
+                        selectedIds.has(req.id)
+                          ? "border-purple-400 dark:border-purple-500 shadow-lg shadow-purple-500/5"
+                          : req.status === "archived"
+                            ? "border-zinc-100 dark:border-zinc-800/50 opacity-60"
+                            : "border-zinc-200 dark:border-zinc-800"
+                      }`}
+                    >
+                      <div className="flex items-start gap-4 w-full">
+                        {isPending && (
+                          <div className="pt-1">
+                            <input
+                              type="checkbox"
+                              checked={selectedIds.has(req.id)}
+                              onChange={() => toggleSelection(req.id)}
+                              className="w-4 h-4 rounded border-zinc-300 dark:border-zinc-700 text-purple-500 focus:ring-purple-500 cursor-pointer"
+                              aria-label={`Select ${req.projectName}`}
+                            />
+                          </div>
+                        )}
 
-                    {req.status === "pending" && (
-                      <div className="flex gap-2 w-full md:w-auto">
-                        <button
-                          onClick={() => handleAction(req.id, "approved")}
-                          className="flex-1 md:flex-none px-4 py-2 bg-green-500 hover:bg-green-600 text-white rounded-xl text-sm font-bold transition-colors"
-                        >
-                          Approve
-                        </button>
-                        <button
-                          onClick={() => handleAction(req.id, "rejected")}
-                          className="flex-1 md:flex-none px-4 py-2 bg-zinc-100 dark:bg-zinc-800 hover:bg-red-500 hover:text-white rounded-xl text-sm font-bold transition-all"
-                        >
-                          Reject
-                        </button>
+                        <div className="flex-1 min-w-0">
+                          <h3 className="font-bold text-lg mb-1">{req.projectName}</h3>
+                          <div className="text-xs text-zinc-500 font-mono flex items-center gap-1.5 flex-wrap">
+                            <span>Submitted by:</span>
+                            <AddressDisplay address={req.submittedBy} copyable={true} truncated={true} inline={true} />
+                            <span className="text-zinc-300 dark:text-zinc-700">•</span>
+                            <span>{formatDate(req.timestamp, "short")}</span>
+                          </div>
+                          <div className="mt-2">
+                            <span
+                              className={`text-[10px] uppercase font-bold px-2 py-1 rounded-full ${STATUS_STYLES[req.status]}`}
+                            >
+                              {req.status}
+                            </span>
+                          </div>
+                        </div>
                       </div>
-                    )}
-                  </div>
-                ))}
+
+                      {isPending && (
+                        <div className="flex gap-2 w-full md:w-auto md:shrink-0">
+                          <button
+                            onClick={() => handleAction(req.id, "approved")}
+                            className="flex-1 md:flex-none px-4 py-2 bg-green-500 hover:bg-green-600 text-white rounded-xl text-sm font-bold transition-colors"
+                          >
+                            Approve
+                          </button>
+                          <button
+                            onClick={() => handleAction(req.id, "rejected")}
+                            className="flex-1 md:flex-none px-4 py-2 bg-zinc-100 dark:bg-zinc-800 hover:bg-red-500 hover:text-white rounded-xl text-sm font-bold transition-all"
+                          >
+                            Reject
+                          </button>
+                        </div>
+                      )}
+                    </div>
+                  );
+                })}
               </div>
             </div>
 
@@ -305,6 +524,50 @@ export default function AdminDashboard() {
                   </div>
                 </div>
               </div>
+            </div>
+          </div>
+        )}
+
+        {/* Floating bulk action bar */}
+        {selectedIds.size > 0 && activeTab === "verification" && (
+          <div className="fixed bottom-8 left-1/2 -translate-x-1/2 z-40 animate-in slide-in-from-bottom-8 fade-in duration-200">
+            <div className="bg-zinc-950 dark:bg-zinc-900 border border-zinc-800 rounded-2xl shadow-2xl px-5 py-3 flex items-center gap-3">
+              <span className="text-sm text-zinc-400 font-medium whitespace-nowrap">
+                {selectedIds.size} selected
+              </span>
+              <div className="w-px h-6 bg-zinc-800" />
+              <div className="flex items-center gap-2">
+                {(Object.entries(BULK_ACTION_CONFIG) as [BulkAction, typeof BULK_ACTION_CONFIG[BulkAction]][]).map(([action, config]) => (
+                  <button
+                    key={action}
+                    onClick={() => handleBulkAction(action)}
+                    disabled={isBulkProcessing}
+                    className={`inline-flex items-center gap-1.5 px-4 py-2 rounded-xl text-sm font-bold transition-all disabled:opacity-50 disabled:pointer-events-none active:scale-[0.98] ${
+                      action === "reject"
+                        ? "bg-red-500/10 text-red-400 hover:bg-red-500/20 hover:text-red-300"
+                        : action === "approve"
+                          ? "bg-green-500/10 text-green-400 hover:bg-green-500/20 hover:text-green-300"
+                          : "bg-zinc-800 text-zinc-300 hover:bg-zinc-700 hover:text-white"
+                    }`}
+                  >
+                    {isBulkProcessing ? (
+                      <span className="w-4 h-4 border-2 border-current border-t-transparent rounded-full animate-spin" />
+                    ) : (
+                      config.icon
+                    )}
+                    {config.label}
+                  </button>
+                ))}
+              </div>
+              <div className="w-px h-6 bg-zinc-800" />
+              <button
+                onClick={clearSelection}
+                disabled={isBulkProcessing}
+                className="p-2 text-zinc-500 hover:text-zinc-300 transition-colors disabled:opacity-50"
+                aria-label="Cancel selection"
+              >
+                <X className="w-4 h-4" />
+              </button>
             </div>
           </div>
         )}


### PR DESCRIPTION
## Summary
Adds bulk selection and bulk actions to the admin verification queue, allowing admins to process multiple queue items at once.

## Changes
- **Checkbox selection**: Each pending verification request now has a checkbox for selection
- **Select-all toggle**: A "Select all pending" checkbox at the top of the list
- **Floating bulk action bar**: When items are selected, a sticky bottom bar appears with actions:
  - **Approve Selected** - Approve all selected requests
  - **Reject Selected** - Reject all selected requests  
  - **Archive Selected** - Archive requests (hide from active queue)
  - **Assign to Me** - Assign requests to the current admin
- **Confirmation dialog**: All bulk actions require confirmation before executing
- **Partial failure reporting**: Results are reported via toast with success/failure counts; failed items show individual reasons
- **Visual feedback**: Selected items get a purple highlight border; processing state shows spinner
- **Archived status**: New "archived" status added for queue items that are hidden from the active queue

## Acceptance Criteria
- [x] Admins can select multiple queue items via checkboxes
- [x] Select-all/deselect-all controls are available
- [x] Bulk actions require confirmation
- [x] Partial failures are reported clearly with detailed toast messages

closes: #259 