### PR TITLE
feat: implement consistent verification status across all project views

### DIFF
--- a/dongle/VERIFICATION_BADGE_IMPLEMENTATION.md
+++ b/dongle/VERIFICATION_BADGE_IMPLEMENTATION.md
@@ -86,6 +86,8 @@ Previously, verification status was only shown in a standalone component on the 
 3. `dongle/app/discover/page.tsx`
 4. `dongle/app/projects/[id]/page.tsx`
 5. `dongle/components/landing/FeaturedProjects.tsx`
+6. `dongle/components/projects/RecentlyViewedProjects.tsx` (Updated)
+7. `dongle/app/profile/page.tsx` (Updated)
 
 ## Usage Example
 

--- a/dongle/app/profile/page.tsx
+++ b/dongle/app/profile/page.tsx
@@ -34,6 +34,8 @@ import { useRecentViews } from "@/hooks/useRecentViews";
 import { RecentlyViewedProjects } from "@/components/projects/RecentlyViewedProjects";
 import { useConfirm } from "@/hooks/useConfirm";
 import { ProjectCard } from "@/components/projects/ProjectCard";
+import type { VerificationStatus } from "@/components/projects/VerificationBadge";
+import { sorobanService } from "@/services/stellar/soroban.service";
 import { useSavedProjects } from "@/hooks/useSavedProjects";
 
 interface StellarNonNativeBalance {
@@ -54,6 +56,7 @@ export default function ProfilePage() {
   const [verificationRequests, setVerificationRequests] = useState<VerificationRequest[]>([]);
   const [loadedVerificationKey, setLoadedVerificationKey] = useState<string | null>(null);
   const [userReviews, setUserReviews] = useState<Review[]>([]);
+  const [savedProjectVerificationStatuses, setSavedProjectVerificationStatuses] = useState<Record<string, VerificationStatus>>({});
 
   const displayedVerificationRequests = gate.publicKey ? verificationRequests : [];
   const loadingVerifications =
@@ -61,6 +64,28 @@ export default function ProfilePage() {
   const savedProjects = savedProjectIds
     .map((projectId) => projectService.getProjectById(projectId))
     .filter((project): project is NonNullable<typeof project> => Boolean(project));
+
+  // Fetch verification statuses for saved projects
+  useEffect(() => {
+    if (savedProjects.length === 0) return;
+
+    const fetchStatuses = async () => {
+      const statuses: Record<string, VerificationStatus> = {};
+      await Promise.all(
+        savedProjects.map(async (project) => {
+          try {
+            const status = await sorobanService.getVerificationStatus(project.id);
+            statuses[project.id] = status;
+          } catch {
+            statuses[project.id] = "NONE";
+          }
+        }),
+      );
+      setSavedProjectVerificationStatuses(statuses);
+    };
+
+    void fetchStatuses();
+  }, [savedProjectIds]);
 
   const handleClearHistory = async () => {
     const ok = await confirm({
@@ -337,7 +362,11 @@ export default function ProfilePage() {
                 {savedProjects.length > 0 ? (
                   <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
                     {savedProjects.map((project) => (
-                      <ProjectCard key={project.id} project={project} />
+                      <ProjectCard
+                        key={project.id}
+                        project={project}
+                        verificationStatus={savedProjectVerificationStatuses[project.id]}
+                      />
                     ))}
                   </div>
                 ) : (

--- a/dongle/components/projects/RecentlyViewedProjects.tsx
+++ b/dongle/components/projects/RecentlyViewedProjects.tsx
@@ -1,8 +1,11 @@
 import { useRouter } from "next/navigation";
+import { useEffect, useState } from "react";
 import { Project } from "@/types/project";
 import { Button } from "@/components/ui/Button";
 import { Badge } from "@/components/ui/Badge";
 import ProjectImage from "@/components/projects/ProjectImage";
+import { VerificationBadge, type VerificationStatus } from "@/components/projects/VerificationBadge";
+import { sorobanService } from "@/services/stellar/soroban.service";
 import { Clock, X, Star } from "lucide-react";
 
 interface RecentlyViewedProjectsProps {
@@ -17,6 +20,29 @@ export function RecentlyViewedProjects({
   compact = false,
 }: RecentlyViewedProjectsProps) {
   const router = useRouter();
+  const [verificationStatuses, setVerificationStatuses] = useState<Record<string, VerificationStatus>>({});
+
+  // Fetch verification statuses for displayed projects
+  useEffect(() => {
+    if (projects.length === 0) return;
+
+    const fetchStatuses = async () => {
+      const statuses: Record<string, VerificationStatus> = {};
+      await Promise.all(
+        projects.map(async (project) => {
+          try {
+            const status = await sorobanService.getVerificationStatus(project.id);
+            statuses[project.id] = status;
+          } catch {
+            statuses[project.id] = "NONE";
+          }
+        }),
+      );
+      setVerificationStatuses(statuses);
+    };
+
+    void fetchStatuses();
+  }, [projects]);
 
   if (projects.length === 0) {
     return null;
@@ -61,6 +87,12 @@ export function RecentlyViewedProjects({
                   <Badge variant="secondary" className="text-xs">
                     {project.primaryCategory}
                   </Badge>
+                  {verificationStatuses[project.id] && (
+                    <VerificationBadge
+                      status={verificationStatuses[project.id]}
+                      showIcon={false}
+                    />
+                  )}
                   <div className="flex items-center gap-1 text-xs text-zinc-500 dark:text-zinc-400">
                     <Star className="w-3 h-3 text-yellow-500 fill-yellow-500" />
                     <span>{project.rating}</span>
@@ -123,6 +155,12 @@ export function RecentlyViewedProjects({
                 <Badge variant="secondary" className="text-xs">
                   {project.primaryCategory}
                 </Badge>
+                {verificationStatuses[project.id] && (
+                  <VerificationBadge
+                    status={verificationStatuses[project.id]}
+                    showIcon={false}
+                  />
+                )}
                 <div className="flex items-center gap-1 text-sm text-zinc-500 dark:text-zinc-400">
                   <Star className="w-4 h-4 text-yellow-500 fill-yellow-500" />
                   <span className="font-bold text-zinc-900 dark:text-zinc-100">

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "Dongle-frontend",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {}
+}


### PR DESCRIPTION
- Fetch verification statuses for recently viewed projects
- Render VerificationBadge in compact and full RecentlyViewedProjects views
- Add verification status state for saved projects on the profile page
- Pass verificationStatus to ProjectCard for saved projects
- Ensure consistent verification badge rendering across all project surfaces
- Preserve Discover verification filtering and existing verification logic
- Standardize visual states for Verified, Pending, Rejected, and Unverified projects

This change completes verification status coverage across the application and ensures a consistent user experience wherever projects are displayed. 
    
Closes #236 