### PR TITLE
fix: resolve duplicate imports breaking saved/bookmarked projects page

### DIFF
--- a/dongle/__tests__/hooks/useSavedProjects.test.ts
+++ b/dongle/__tests__/hooks/useSavedProjects.test.ts
@@ -1,0 +1,129 @@
+/**
+ * Tests for useSavedProjects hook
+ */
+
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { useSavedProjects } from "@/hooks/useSavedProjects";
+import { useWallet } from "@/context/wallet.context";
+
+vi.mock("@/context/wallet.context", () => ({
+  useWallet: vi.fn(),
+}));
+
+const mockUseWallet = vi.mocked(useWallet);
+
+const WALLET_A = "GABC1234567890WALLETA";
+const WALLET_B = "GXYZ0987654321WALLETB";
+
+function mockWallet(publicKey: string | null, isConnected = Boolean(publicKey)) {
+  mockUseWallet.mockReturnValue({
+    publicKey,
+    isConnected,
+  } as unknown as ReturnType<typeof useWallet>);
+}
+
+describe("useSavedProjects hook", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    vi.clearAllMocks();
+  });
+
+  describe("Acceptance Criteria: Connected users can save and unsave projects", () => {
+    it("reports canManageSavedProjects false when wallet is not connected", () => {
+      mockWallet(null, false);
+      const { result } = renderHook(() => useSavedProjects());
+
+      expect(result.current.canManageSavedProjects).toBe(false);
+    });
+
+    it("does nothing when toggling while disconnected", () => {
+      mockWallet(null, false);
+      const { result } = renderHook(() => useSavedProjects());
+
+      act(() => {
+        result.current.toggleSavedProject("project-1");
+      });
+
+      expect(result.current.savedProjectIds).toEqual([]);
+    });
+
+    it("saves a project for a connected wallet", () => {
+      mockWallet(WALLET_A);
+      const { result } = renderHook(() => useSavedProjects());
+
+      act(() => {
+        result.current.toggleSavedProject("project-1");
+      });
+
+      expect(result.current.savedProjectIds).toEqual(["project-1"]);
+      expect(result.current.isProjectSaved("project-1")).toBe(true);
+    });
+
+    it("unsaves a project when toggled again", () => {
+      mockWallet(WALLET_A);
+      const { result } = renderHook(() => useSavedProjects());
+
+      act(() => {
+        result.current.toggleSavedProject("project-1");
+      });
+      expect(result.current.isProjectSaved("project-1")).toBe(true);
+
+      act(() => {
+        result.current.toggleSavedProject("project-1");
+      });
+
+      expect(result.current.isProjectSaved("project-1")).toBe(false);
+      expect(result.current.savedProjectIds).toEqual([]);
+    });
+  });
+
+  describe("Acceptance Criteria: Bookmarks are wallet-scoped", () => {
+    it("keeps saved projects separate per wallet address", () => {
+      mockWallet(WALLET_A);
+      const { result: resultA, rerender: rerenderA } = renderHook(() => useSavedProjects());
+
+      act(() => {
+        resultA.current.toggleSavedProject("project-1");
+      });
+      expect(resultA.current.savedProjectIds).toEqual(["project-1"]);
+
+      mockWallet(WALLET_B);
+      const { result: resultB } = renderHook(() => useSavedProjects());
+
+      expect(resultB.current.savedProjectIds).toEqual([]);
+
+      act(() => {
+        resultB.current.toggleSavedProject("project-2");
+      });
+
+      expect(resultB.current.savedProjectIds).toEqual(["project-2"]);
+
+      // Wallet A's saved list is untouched by wallet B's changes
+      mockWallet(WALLET_A);
+      rerenderA();
+      expect(resultA.current.savedProjectIds).toEqual(["project-1"]);
+    });
+  });
+
+  describe("Acceptance Criteria: Users can clear all saved projects", () => {
+    it("clears saved projects for the connected wallet", () => {
+      mockWallet(WALLET_A);
+      const { result } = renderHook(() => useSavedProjects());
+
+      act(() => {
+        result.current.toggleSavedProject("project-1");
+      });
+      act(() => {
+        result.current.toggleSavedProject("project-2");
+      });
+      expect(result.current.savedProjectIds).toHaveLength(2);
+
+      act(() => {
+        result.current.clearSavedProjects();
+      });
+
+      expect(result.current.savedProjectIds).toEqual([]);
+    });
+  });
+});

--- a/dongle/app/projects/[id]/page.tsx
+++ b/dongle/app/projects/[id]/page.tsx
@@ -17,7 +17,6 @@ import { projectReportService } from "@/services/project/project-report.service"
 import { projectClaimService } from "@/services/project/project-claim.service";
 import { formatDate } from "@/lib/date";
 import { reviewService, getReviewPersistenceLabel } from "@/services/review/review.service";
-import { reviewReportService } from "@/services/review/review-report.service";
 import { sorobanService } from "@/services/stellar/soroban.service";
 import { extractDomain } from "@/lib/url";
 import { useWalletPageGate } from "@/hooks/useWalletPageGate";
@@ -36,13 +35,9 @@ import {
   GitBranch,
   Globe,
   Info,
-  Bookmark,
-  BookmarkCheck,
   Shield,
-  Bug,
   Megaphone,
   MessageSquare,
-  Shield,
   Star,
   UserPlus,
 } from "lucide-react";


### PR DESCRIPTION
## Summary
Closes #246.

Investigating this issue, the saved/bookmarked projects feature itself was already implemented on `main`:
- `hooks/useSavedProjects.ts` — wallet-scoped save/unsave, backed by localStorage keyed per wallet address, with cross-tab sync via `storage`/custom events.
- `components/projects/ProjectCard.tsx` — bookmark toggle button reflecting saved state on every card.
- `app/projects/[id]/page.tsx` — bookmark toggle on the project detail page, prompting wallet connection when disconnected.
- `app/profile/page.tsx` — "Saved Projects" section rendering the connected wallet's bookmarked projects.

However, `app/projects/[id]/page.tsx` had duplicate named imports (`Bookmark`, `BookmarkCheck`, `Bug`, `Shield` from `lucide-react`, and `reviewReportService`) which are `TS2300: Duplicate identifier` errors — these broke compilation of the project detail page entirely (verified with `tsc --noEmit`, isolating from an unrelated pre-existing syntax error in `app/admin/page.tsx` that had been masking it). This PR:
- Removes the duplicate imports so the page (and therefore the bookmark toggle acceptance criteria) actually builds.
- Adds `__tests__/hooks/useSavedProjects.test.ts`, covering save/unsave for connected users, wallet-scoped isolation between different wallets, and clearing saved projects — none of which had test coverage before.

## Acceptance criteria
- [x] Connected users can save and unsave projects.
- [x] Saved projects appear on Profile.
- [x] Bookmark state is reflected on cards and detail pages.

## Test plan
- [x] `npx tsc --noEmit` — no more duplicate-identifier errors on `app/projects/[id]/page.tsx`
- [x] `npx vitest --run __tests__/hooks/useSavedProjects.test.ts` — 6/6 passing
- [x] `npx vitest --run __tests__/pages/ProjectDetail.test.tsx __tests__/pages/Discover.test.tsx __tests__/components/FeaturedProjects.test.tsx __tests__/integration/discover-to-detail.test.ts` — 46/46 passing
- [x] Full suite `npx vitest --run` — no new failures (2 pre-existing, unrelated failures in `stellar-address.test.ts`)