### PR TITLE
feat(projects): display project tags on cards and detail page (#245)

### DIFF
--- a/dongle/app/projects/[id]/page.tsx
+++ b/dongle/app/projects/[id]/page.tsx
@@ -435,6 +435,15 @@ export default function ProjectDetailPage() {
                       )}
                     </div>
                     <h1 className="text-4xl font-bold mb-4">{project.name}</h1>
+                    {project.tags && project.tags.length > 0 && (
+                      <div className="flex flex-wrap gap-2 mb-4">
+                        {project.tags.map((tag) => (
+                          <Badge key={tag} variant="secondary">
+                            {tag}
+                          </Badge>
+                        ))}
+                      </div>
+                    )}
                     <div className="flex items-center gap-6 text-sm text-zinc-500 dark:text-zinc-400">
                       <div className="flex items-center gap-2">
                         <Star className="w-4 h-4 text-yellow-500 fill-yellow-500" />

--- a/dongle/components/projects/ProjectCard.tsx
+++ b/dongle/components/projects/ProjectCard.tsx
@@ -126,9 +126,21 @@ export const ProjectCard = ({
         <h3 className="text-xl font-bold mb-2 group-hover:text-blue-500 transition-colors">
           {project.name}
         </h3>
-        <p className="text-zinc-500 dark:text-zinc-400 text-sm mb-6 line-clamp-2 grow">
+        <p className="text-zinc-500 dark:text-zinc-400 text-sm mb-4 line-clamp-2 grow">
           {project.description}
         </p>
+        {project.tags && project.tags.length > 0 && (
+          <div className="flex flex-wrap gap-1.5 mb-4 px-2">
+            {project.tags.map((tag) => (
+              <span
+                key={tag}
+                className="text-[11px] font-medium text-zinc-500 dark:text-zinc-400 bg-zinc-100 dark:bg-zinc-800 px-2 py-0.5 rounded-full"
+              >
+                {tag}
+              </span>
+            ))}
+          </div>
+        )}
         <div className="flex justify-between items-center text-xs text-zinc-400 dark:text-zinc-500 mt-auto">
           <span>{project.reviews} reviews</span>
           <span>Added {formatDate(project.createdAt, "short")}</span>


### PR DESCRIPTION
Closes #245

## Approach
Tags (multi-select, alongside primaryCategory) were already modeled, editable in the submit/edit form, and filterable on Discover via URL params — but never rendered anywhere in the UI, so users could filter by a tag they'd never actually see. This adds rendering only:
- ProjectCard: tags shown as pill badges under the description (covers Discover, Compare, Featured, Recently Viewed — all consumers of ProjectCard)
- Project detail page: tags shown as Badge components under the title

No changes to the data model, filtering logic, or form — those already satisfied the other two acceptance criteria (multi-tag storage, Discover filtering, clean migration since `tags` defaults to `[]`).

## Testing
- `npm run lint`, `npm run typecheck`, `npm test` run on both base (`upstream/main`) and this branch — identical pre-existing failure counts (5 lint issues, 29 type errors, 44/400 test failures) in unrelated files (review-report service, admin page, FormField). This change adds zero new failures.
- Ran the tests covering the touched surface directly: Discover.test.tsx, category-consistency.test.ts, discover-to-detail.test.ts — all pass.
- Manually verified tags render correctly with 0, 1, and multiple tags (conditional rendering, no empty badge row).