### PR TITLE
fix: persist verification requests and wire admin approval flow

### DIFF
--- a/dongle/__tests__/components/RatingDistributionSummary.test.tsx
+++ b/dongle/__tests__/components/RatingDistributionSummary.test.tsx
@@ -1,0 +1,61 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import {
+  RatingDistributionSummary,
+  computeRatingDistribution,
+} from "@/components/reviews/RatingDistributionSummary";
+
+describe("computeRatingDistribution", () => {
+  it("counts reviews per star rating", () => {
+    const dist = computeRatingDistribution([
+      { rating: 5 },
+      { rating: 5 },
+      { rating: 4 },
+      { rating: 1 },
+    ]);
+
+    expect(dist).toEqual({ 5: 2, 4: 1, 3: 0, 2: 0, 1: 1 });
+  });
+
+  it("ignores invalid ratings", () => {
+    const dist = computeRatingDistribution([
+      { rating: 0 },
+      { rating: 6 },
+      { rating: 3 },
+    ]);
+
+    expect(dist[3]).toBe(1);
+    expect(dist[5]).toBe(0);
+  });
+});
+
+describe("RatingDistributionSummary", () => {
+  it("shows empty state when there are no reviews", () => {
+    render(
+      <RatingDistributionSummary
+        distribution={{ 5: 0, 4: 0, 3: 0, 2: 0, 1: 0 }}
+        totalReviews={0}
+        averageRating={0}
+      />,
+    );
+
+    expect(
+      screen.getByText(/rating distribution will appear once users leave feedback/i),
+    ).toBeInTheDocument();
+  });
+
+  it("renders per-star counts and percentages", () => {
+    render(
+      <RatingDistributionSummary
+        distribution={{ 5: 2, 4: 1, 3: 0, 2: 0, 1: 0 }}
+        totalReviews={3}
+        averageRating={4.7}
+      />,
+    );
+
+    expect(screen.getByText("4.7")).toBeInTheDocument();
+    expect(screen.getByText("3 total reviews")).toBeInTheDocument();
+    expect(screen.getByText("2 (67%)")).toBeInTheDocument();
+    expect(screen.getByText("1 (33%)")).toBeInTheDocument();
+  });
+});

--- a/dongle/__tests__/services/project-submission.service.test.ts
+++ b/dongle/__tests__/services/project-submission.service.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { projectSubmissionService } from "@/services/project/project-submission.service";
+
+describe("projectSubmissionService", () => {
+  beforeEach(() => {
+    vi.stubGlobal("localStorage", {
+      store: {} as Record<string, string>,
+      getItem(key: string) {
+        return this.store[key] ?? null;
+      },
+      setItem(key: string, value: string) {
+        this.store[key] = value;
+      },
+      removeItem(key: string) {
+        delete this.store[key];
+      },
+      clear() {
+        this.store = {};
+      },
+    });
+    localStorage.clear();
+  });
+
+  it("auto-flags submissions with multiple suspicious signals", () => {
+    const submission = projectSubmissionService.recordSubmission({
+      projectId: "scam-dex",
+      projectName: "Scam DEX",
+      submittedBy: "GTEST123",
+      qualityScore: 30,
+      flagReasons: ["Low quality score", "No audit report provided"],
+    });
+
+    expect(submission.status).toBe("flagged");
+    expect(projectSubmissionService.isDiscoverable("scam-dex")).toBe(false);
+  });
+
+  it("approves clean submissions and hides rejected ones from discover", () => {
+    projectSubmissionService.recordSubmission({
+      projectId: "clean-app",
+      projectName: "Clean App",
+      submittedBy: "GTEST123",
+      qualityScore: 90,
+      flagReasons: [],
+    });
+
+    expect(projectSubmissionService.isDiscoverable("clean-app")).toBe(true);
+
+    projectSubmissionService.updateStatus(
+      "clean-app",
+      "rejected",
+      "GADMIN123",
+      "Spam",
+    );
+
+    expect(projectSubmissionService.isDiscoverable("clean-app")).toBe(false);
+  });
+
+  it("returns discoverable for projects without moderation records", () => {
+    expect(projectSubmissionService.isDiscoverable("legacy-project")).toBe(true);
+  });
+});

--- a/dongle/app/admin/page.tsx
+++ b/dongle/app/admin/page.tsx
@@ -1,7 +1,12 @@
 "use client";
-import { ProjectReport, ProjectClaimRequest, ProjectModerationAction } from "@/types/project";
+import {
+  ProjectReport,
+  ProjectClaimRequest,
+  ProjectModerationAction,
+  ProjectSubmission,
+} from "@/types/project";
 
-import { useState, useEffect } from "react";
+import { useState, useEffect, useCallback } from "react";
 import { toast } from "sonner";
 import AddressDisplay from "@/components/ui/AddressDisplay";
 import WalletStatePanel, {
@@ -10,29 +15,34 @@ import WalletStatePanel, {
 import { useAdminAccess } from "@/hooks/useAdminAccess";
 import { useConfirm } from "@/hooks/useConfirm";
 import { formatDate } from "@/lib/date";
-import { AlertCircle, Flag, Shield, CheckCircle, XCircle, Clock, MessageSquare, ScrollText, User, UserMinus } from "lucide-react";
+import {
+  AlertCircle,
+  Flag,
+  Shield,
+  CheckCircle,
+  XCircle,
+  Clock,
+  MessageSquare,
+  ScrollText,
+  User,
+  UserMinus,
+  Package,
+} from "lucide-react";
 import { reviewReportService } from "@/services/review/review-report.service";
 import { projectReportService } from "@/services/project/project-report.service";
 import { projectClaimService } from "@/services/project/project-claim.service";
+import { projectSubmissionService } from "@/services/project/project-submission.service";
 import { projectService } from "@/services/project/project.service";
 import { reviewService } from "@/services/review/review.service";
 import { auditLogService } from "@/services/audit/audit-log.service";
-import { verificationService } from "@/services/stellar/verification.service";
+import {
+  verificationService,
+  type VerificationRequest,
+} from "@/services/stellar/verification.service";
 import { ReviewReport, ModerationAction, Review } from "@/types/review";
-import { ProjectReport, ProjectClaimRequest, ProjectModerationAction } from "@/types/project";
 import AuditLogViewer from "@/components/admin/AuditLogViewer";
 import Pagination from "@/components/ui/Pagination";
 import { usePagination } from "@/hooks/usePagination";
-
-type RequestStatus = "pending" | "approved" | "rejected" | "archived";
-
-interface VerificationRequest {
-  id: string;
-  projectName: string;
-  submittedBy: string;
-  status: RequestStatus;
-  timestamp: string;
-}
 
 type BulkAction = "approve" | "reject" | "archive" | "assign";
 
@@ -42,20 +52,21 @@ interface BulkActionResult {
   failed: { id: string; reason: string }[];
 }
 
-const MOCK_REQUESTS: VerificationRequest[] = [
-  { id: "req_1", projectName: "Lumina DEX", submittedBy: "GABC...1234", status: "pending", timestamp: "2024-03-20T10:00:00Z" },
-  { id: "req_2", projectName: "Stellar Stake", submittedBy: "GDEF...5678", status: "pending", timestamp: "2024-03-21T14:30:00Z" },
-  { id: "req_3", projectName: "Orbit NFT", submittedBy: "GHIJ...9012", status: "approved", timestamp: "2024-03-19T09:15:00Z" },
-];
-
 const ADMIN_PURPOSE =
   "Connect an authorized admin Freighter wallet to manage verification requests, review reports, and system settings.";
 
-const STATUS_STYLES: Record<RequestStatus, string> = {
+const VERIFICATION_STATUS_STYLES: Record<VerificationRequest["status"], string> = {
+  PENDING: "bg-yellow-100 text-yellow-700 dark:bg-yellow-900/30 dark:text-yellow-500",
+  VERIFIED: "bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-500",
+  REJECTED: "bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-500",
+  NONE: "bg-zinc-100 text-zinc-500 dark:bg-zinc-800/50 dark:text-zinc-400",
+};
+
+const SUBMISSION_STATUS_STYLES: Record<ProjectSubmission["status"], string> = {
   pending: "bg-yellow-100 text-yellow-700 dark:bg-yellow-900/30 dark:text-yellow-500",
   approved: "bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-500",
   rejected: "bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-500",
-  archived: "bg-zinc-100 text-zinc-500 dark:bg-zinc-800/50 dark:text-zinc-400",
+  flagged: "bg-orange-100 text-orange-700 dark:bg-orange-900/30 dark:text-orange-500",
 };
 
 const BULK_ACTION_CONFIG: Record<BulkAction, { label: string; icon: React.ReactNode; confirmTitle: string; confirmDescription: (count: number) => string }> = {
@@ -132,9 +143,18 @@ function reportBulkActionResult(result: BulkActionResult) {
 export default function AdminDashboard() {
   const { isAdmin, isAdminChecking, gate } = useAdminAccess();
   const confirm = useConfirm();
-  const [requests, setRequests] = useState<VerificationRequest[]>(MOCK_REQUESTS);
+  const [requests, setRequests] = useState<VerificationRequest[]>([]);
+  const [submissions, setSubmissions] = useState<ProjectSubmission[]>([]);
+  const [verificationStats, setVerificationStats] = useState({
+    total: 0,
+    pending: 0,
+    verified: 0,
+    rejected: 0,
+  });
   const [fee, setFee] = useState(1.5);
-  const [activeTab, setActiveTab] = useState<"verification" | "reports" | "audit-log">("verification");
+  const [activeTab, setActiveTab] = useState<
+    "verification" | "submissions" | "reports" | "audit-log"
+  >("verification");
   const [reports, setReports] = useState<ReviewReport[]>([]);
   const [reviews, setReviews] = useState<Review[]>([]);
   const [projectReports, setProjectReports] = useState<ProjectReport[]>([]);
@@ -148,10 +168,24 @@ export default function AdminDashboard() {
   const [claimReason, setClaimReason] = useState<Record<string, string>>({});
   const [projectReportReason, setProjectReportReason] = useState<Record<string, string>>({});
   const [expandedReport, setExpandedReport] = useState<string | null>(null);
+  const [submissionReason, setSubmissionReason] = useState<Record<string, string>>({});
   const [verificationFilter, setVerificationFilter] = useState<"all" | "assigned-to-me" | "unassigned">("all");
   const [reportFilter, setReportFilter] = useState<"all" | "assigned-to-me" | "unassigned">("all");
 
-  // Load reports, reviews, and moderation log
+  const reloadVerificationRequests = useCallback(async () => {
+    const [allRequests, stats] = await Promise.all([
+      verificationService.getAllRequests(),
+      verificationService.getStats(),
+    ]);
+    setRequests(allRequests);
+    setVerificationStats(stats);
+  }, []);
+
+  const reloadSubmissions = useCallback(() => {
+    setSubmissions(projectSubmissionService.getAllSubmissions());
+  }, []);
+
+  // Load reports, reviews, verification requests, and moderation log
   useEffect(() => {
     if (!isAdmin) return;
     const id = setTimeout(() => {
@@ -161,20 +195,35 @@ export default function AdminDashboard() {
       setClaimRequests(projectClaimService.getRequests());
       setModerationLog(reviewReportService.getModerationLog());
       setProjectModerationLog(projectReportService.getModerationLog());
+      void reloadVerificationRequests();
+      reloadSubmissions();
     }, 0);
     return () => clearTimeout(id);
-  }, [isAdmin]);
+  }, [isAdmin, reloadVerificationRequests, reloadSubmissions]);
 
-  const handleAction = (id: string, status: "approved" | "rejected", reason?: string) => {
-    const req = requests.find((r) => r.id === id);
+  const handleAction = async (
+    projectId: string,
+    status: "approved" | "rejected",
+    reason?: string,
+  ) => {
+    const req = requests.find((r) => r.projectId === projectId);
     if (!reason?.trim() && status === "rejected") {
       toast.error("A reason is required for rejection");
       return;
     }
-    setRequests((prev) =>
-      prev.map((r) => (r.id === id ? { ...r, status } : r)),
-    );
-    if (req && gate.publicKey) {
+    if (!gate.publicKey || !req) return;
+
+    try {
+      if (status === "approved") {
+        await verificationService.approveRequest(projectId, gate.publicKey);
+      } else {
+        await verificationService.rejectRequest(
+          projectId,
+          gate.publicKey,
+          reason?.trim(),
+        );
+      }
+
       auditLogService.append({
         actor: gate.publicKey,
         action: status === "approved" ? "verification_approved" : "verification_rejected",
@@ -182,9 +231,50 @@ export default function AdminDashboard() {
         targetLabel: req.projectName,
         reason: reason?.trim() || undefined,
       });
+
+      await reloadVerificationRequests();
+      toast.success(`Verification ${status === "approved" ? "approved" : "rejected"}`);
+      setVerificationReason((prev) => ({ ...prev, [projectId]: "" }));
+    } catch (error) {
+      toast.error(
+        error instanceof Error ? error.message : "Failed to update verification request",
+      );
     }
-    toast.success(`Verification ${status === "approved" ? "approved" : "rejected"}`);
-    setVerificationReason((prev) => ({ ...prev, [id]: "" }));
+  };
+
+  const handleSubmissionAction = (
+    projectId: string,
+    status: "approved" | "rejected" | "flagged",
+    reason?: string,
+  ) => {
+    if ((status === "rejected" || status === "flagged") && !reason?.trim()) {
+      toast.error("A reason is required");
+      return;
+    }
+    if (!gate.publicKey) return;
+
+    const result = projectSubmissionService.updateStatus(
+      projectId,
+      status,
+      gate.publicKey,
+      reason?.trim(),
+    );
+
+    if (result.success) {
+      auditLogService.append({
+        actor: gate.publicKey,
+        action: "submission_moderated",
+        targetId: projectId,
+        targetLabel: result.submission?.projectName ?? projectId,
+        reason: reason?.trim() || `Marked as ${status}`,
+        metadata: { status },
+      });
+      reloadSubmissions();
+      toast.success(`Submission ${status}`);
+      setSubmissionReason((prev) => ({ ...prev, [projectId]: "" }));
+    } else {
+      toast.error(result.error || "Failed to update submission");
+    }
   };
 
   const toggleSelection = useCallback((id: string) => {
@@ -384,43 +474,39 @@ export default function AdminDashboard() {
     }
   };
 
-  const handleAssignVerification = async (requestId: string, assignedTo: string) => {
+  const handleAssignVerification = async (projectId: string, assignedTo: string) => {
     if (!gate.publicKey) return;
 
     try {
-      await verificationService.assignRequest(requestId, gate.publicKey, assignedTo);
+      await verificationService.assignRequest(projectId, gate.publicKey, assignedTo);
       auditLogService.append({
         actor: gate.publicKey,
         action: "verification_assigned",
-        targetId: requestId,
-        targetLabel: `Verification Request ${requestId}`,
+        targetId: projectId,
+        targetLabel: `Verification Request ${projectId}`,
         metadata: { assignedTo },
       });
       toast.success("Request assigned");
-      setRequests((prev) => prev.map((r: any) => 
-        r.id === requestId ? { ...r, assignedTo, assignedAt: new Date().toISOString() } : r
-      ));
-    } catch (error) {
+      await reloadVerificationRequests();
+    } catch {
       toast.error("Failed to assign request");
     }
   };
 
-  const handleUnassignVerification = async (requestId: string) => {
+  const handleUnassignVerification = async (projectId: string) => {
     if (!gate.publicKey) return;
 
     try {
-      await verificationService.unassignRequest(requestId, gate.publicKey);
+      await verificationService.unassignRequest(projectId, gate.publicKey);
       auditLogService.append({
         actor: gate.publicKey,
         action: "verification_unassigned",
-        targetId: requestId,
-        targetLabel: `Verification Request ${requestId}`,
+        targetId: projectId,
+        targetLabel: `Verification Request ${projectId}`,
       });
       toast.success("Request unassigned");
-      setRequests((prev) => prev.map((r: any) => 
-        r.id === requestId ? { ...r, assignedTo: undefined, assignedAt: undefined } : r
-      ));
-    } catch (error) {
+      await reloadVerificationRequests();
+    } catch {
       toast.error("Failed to unassign request");
     }
   };
@@ -470,6 +556,9 @@ export default function AdminDashboard() {
     return moderationLog.filter((a) => a.reportId === reportId);
   };
 
+  const pendingSubmissions = submissions.filter(
+    (s) => s.status === "pending" || s.status === "flagged",
+  );
   const pendingReports = reports.filter((r) => r.status === "pending");
   const resolvedReports = reports.filter((r) => r.status !== "pending");
   const pendingProjectReports = projectReports.filter((report) => report.status === "pending");
@@ -544,6 +633,25 @@ export default function AdminDashboard() {
           >
             Verification Requests
             {activeTab === "verification" && (
+              <div className="absolute bottom-0 left-0 right-0 h-0.5 bg-blue-600 dark:bg-blue-400" />
+            )}
+          </button>
+          <button
+            onClick={() => setActiveTab("submissions")}
+            className={`pb-3 px-1 font-medium transition-colors relative flex items-center gap-2 ${
+              activeTab === "submissions"
+                ? "text-blue-600 dark:text-blue-400"
+                : "text-zinc-500 dark:text-zinc-400 hover:text-zinc-900 dark:hover:text-zinc-100"
+            }`}
+          >
+            <Package className="w-4 h-4" />
+            Submissions
+            {pendingSubmissions.length > 0 && (
+              <span className="bg-orange-100 dark:bg-orange-900/30 text-orange-700 dark:text-orange-400 text-xs font-bold px-2 py-0.5 rounded-full">
+                {pendingSubmissions.length}
+              </span>
+            )}
+            {activeTab === "submissions" && (
               <div className="absolute bottom-0 left-0 right-0 h-0.5 bg-blue-600 dark:bg-blue-400" />
             )}
           </button>
@@ -626,34 +734,29 @@ export default function AdminDashboard() {
 
               <div className="space-y-4">
                 {requests
-                  .filter((req: any) => {
+                  .filter((req) => {
                     if (verificationFilter === "all") return true;
                     if (verificationFilter === "assigned-to-me") return req.assignedTo === gate.publicKey;
                     if (verificationFilter === "unassigned") return !req.assignedTo;
                     return true;
                   })
-                  .map((req: any) => (
+                  .map((req) => (
                   <div
                     key={req.id}
                     className="bg-white dark:bg-zinc-900 border border-zinc-200 dark:border-zinc-800 p-6 rounded-3xl flex flex-col md:flex-row justify-between items-start md:items-center gap-4 transition-all hover:shadow-lg"
                   >
                     <div className="flex-1">
                       <h3 className="font-bold text-lg mb-1">{req.projectName}</h3>
+                      <p className="text-xs text-zinc-400 font-mono mb-1">{req.projectId}</p>
                       <div className="text-xs text-zinc-500 font-mono flex items-center gap-1.5 flex-wrap">
                         <span>Submitted by:</span>
                         <AddressDisplay address={req.submittedBy} copyable={true} truncated={true} inline={true} />
                         <span className="text-zinc-300 dark:text-zinc-700">•</span>
-                        <span>{formatDate(req.timestamp, "short")}</span>
+                        <span>{formatDate(req.submittedAt, "short")}</span>
                       </div>
                       <div className="mt-2 flex items-center gap-2">
                         <span
-                          className={`text-[10px] uppercase font-bold px-2 py-1 rounded-full ${
-                            req.status === "pending"
-                              ? "bg-yellow-100 text-yellow-700 dark:bg-yellow-900/30 dark:text-yellow-500"
-                              : req.status === "approved"
-                                ? "bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-500"
-                                : "bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-500"
-                          }`}
+                          className={`text-[10px] uppercase font-bold px-2 py-1 rounded-full ${VERIFICATION_STATUS_STYLES[req.status]}`}
                         >
                           {req.status}
                         </span>
@@ -669,7 +772,7 @@ export default function AdminDashboard() {
                       {req.assignedTo ? (
                         req.assignedTo === gate.publicKey ? (
                           <button
-                            onClick={() => handleUnassignVerification(req.id)}
+                            onClick={() => handleUnassignVerification(req.projectId)}
                             className="flex-1 md:flex-none px-3 py-2 bg-zinc-100 dark:bg-zinc-800 hover:bg-zinc-200 dark:hover:bg-zinc-700 rounded-xl text-sm font-medium transition-colors flex items-center gap-2"
                           >
                             <UserMinus className="w-4 h-4" />
@@ -677,7 +780,7 @@ export default function AdminDashboard() {
                           </button>
                         ) : (
                           <button
-                            onClick={() => handleAssignVerification(req.id, gate.publicKey!)}
+                            onClick={() => handleAssignVerification(req.projectId, gate.publicKey!)}
                             className="flex-1 md:flex-none px-3 py-2 bg-blue-500 hover:bg-blue-600 text-white rounded-xl text-sm font-medium transition-colors flex items-center gap-2"
                           >
                             <User className="w-4 h-4" />
@@ -686,23 +789,26 @@ export default function AdminDashboard() {
                         )
                       ) : (
                         <button
-                          onClick={() => handleAssignVerification(req.id, gate.publicKey!)}
+                          onClick={() => handleAssignVerification(req.projectId, gate.publicKey!)}
                           className="flex-1 md:flex-none px-3 py-2 bg-blue-500 hover:bg-blue-600 text-white rounded-xl text-sm font-medium transition-colors flex items-center gap-2"
                         >
                           <User className="w-4 h-4" />
                           Assign to me
                         </button>
                       )}
-                      {req.status === "pending" && (
+                      {req.status === "PENDING" && (
                         <>
                           <button
-                            onClick={() => handleAction(req.id, "approved")}
+                            onClick={() => handleAction(req.projectId, "approved")}
                             className="flex-1 md:flex-none px-4 py-2 bg-green-500 hover:bg-green-600 text-white rounded-xl text-sm font-bold transition-colors"
                           >
                             Approve
                           </button>
                           <button
-                            onClick={() => handleAction(req.id, "rejected")}
+                            onClick={() => {
+                              const reason = verificationReason[req.projectId];
+                              handleAction(req.projectId, "rejected", reason);
+                            }}
                             className="flex-1 md:flex-none px-4 py-2 bg-zinc-100 dark:bg-zinc-800 hover:bg-red-500 hover:text-white rounded-xl text-sm font-bold transition-all"
                           >
                             Reject
@@ -751,12 +857,12 @@ export default function AdminDashboard() {
                 <h3 className="font-bold mb-4">Stats Overview</h3>
                 <div className="grid grid-cols-2 gap-4">
                   <div className="bg-zinc-50 dark:bg-zinc-800/50 p-4 rounded-2xl">
-                    <div className="text-xs text-zinc-500 uppercase font-bold mb-1">Active</div>
-                    <div className="text-2xl font-black">24</div>
+                    <div className="text-xs text-zinc-500 uppercase font-bold mb-1">Verified</div>
+                    <div className="text-2xl font-black">{verificationStats.verified}</div>
                   </div>
                   <div className="bg-zinc-50 dark:bg-zinc-800/50 p-4 rounded-2xl">
                     <div className="text-xs text-zinc-500 uppercase font-bold mb-1">Queue</div>
-                    <div className="text-2xl font-black">12</div>
+                    <div className="text-2xl font-black">{verificationStats.pending}</div>
                   </div>
                 </div>
               </div>
@@ -805,6 +911,128 @@ export default function AdminDashboard() {
                 <X className="w-4 h-4" />
               </button>
             </div>
+          </div>
+        )}
+
+        {activeTab === "submissions" && (
+          <div className="space-y-6">
+            <div className="flex items-center justify-between">
+              <h2 className="text-xl font-bold flex items-center gap-2">
+                <span className="w-2 h-8 bg-orange-500 rounded-full" />
+                Project Submission Moderation
+                {pendingSubmissions.length > 0 && (
+                  <span className="text-sm font-normal text-zinc-500 dark:text-zinc-400">
+                    ({pendingSubmissions.length} in queue)
+                  </span>
+                )}
+              </h2>
+            </div>
+
+            {submissions.length === 0 ? (
+              <div className="text-center py-16 bg-white dark:bg-zinc-900 border border-zinc-200 dark:border-zinc-800 rounded-3xl">
+                <Package className="w-12 h-12 text-zinc-300 mx-auto mb-4" />
+                <p className="text-zinc-500">No project submissions to review yet.</p>
+              </div>
+            ) : (
+              <div className="space-y-4">
+                {submissions.map((submission) => (
+                  <div
+                    key={submission.id}
+                    className="bg-white dark:bg-zinc-900 border border-zinc-200 dark:border-zinc-800 p-6 rounded-3xl"
+                  >
+                    <div className="flex flex-col md:flex-row justify-between gap-4">
+                      <div className="flex-1">
+                        <h3 className="font-bold text-lg mb-1">{submission.projectName}</h3>
+                        <p className="text-xs text-zinc-400 font-mono mb-2">{submission.projectId}</p>
+                        <div className="text-xs text-zinc-500 flex items-center gap-1.5 flex-wrap mb-3">
+                          <span>Submitted by:</span>
+                          <AddressDisplay
+                            address={submission.submittedBy}
+                            copyable={true}
+                            truncated={true}
+                            inline={true}
+                          />
+                          <span className="text-zinc-300 dark:text-zinc-700">•</span>
+                          <span>{formatDate(submission.submittedAt, "short")}</span>
+                          <span className="text-zinc-300 dark:text-zinc-700">•</span>
+                          <span>Quality: {submission.qualityScore}%</span>
+                        </div>
+                        <span
+                          className={`text-[10px] uppercase font-bold px-2 py-1 rounded-full ${SUBMISSION_STATUS_STYLES[submission.status]}`}
+                        >
+                          {submission.status}
+                        </span>
+                        {submission.flagReasons.length > 0 && (
+                          <ul className="mt-3 text-xs text-orange-600 dark:text-orange-400 space-y-1">
+                            {submission.flagReasons.map((flag) => (
+                              <li key={flag}>• {flag}</li>
+                            ))}
+                          </ul>
+                        )}
+                        {submission.rejectionReason && (
+                          <p className="mt-2 text-xs text-red-600 dark:text-red-400">
+                            Reason: {submission.rejectionReason}
+                          </p>
+                        )}
+                      </div>
+
+                      {(submission.status === "pending" || submission.status === "flagged") && (
+                        <div className="flex flex-col gap-2 w-full md:w-64">
+                          <input
+                            type="text"
+                            placeholder="Reason (required for reject/flag)"
+                            value={submissionReason[submission.projectId] || ""}
+                            onChange={(e) =>
+                              setSubmissionReason((prev) => ({
+                                ...prev,
+                                [submission.projectId]: e.target.value,
+                              }))
+                            }
+                            className="px-3 py-2 bg-zinc-50 dark:bg-zinc-800 border border-zinc-200 dark:border-zinc-700 rounded-xl text-sm"
+                          />
+                          <div className="flex gap-2">
+                            <button
+                              onClick={() =>
+                                handleSubmissionAction(submission.projectId, "approved")
+                              }
+                              className="flex-1 px-3 py-2 bg-green-500 hover:bg-green-600 text-white rounded-xl text-sm font-bold"
+                            >
+                              Approve
+                            </button>
+                            <button
+                              onClick={() =>
+                                handleSubmissionAction(
+                                  submission.projectId,
+                                  "rejected",
+                                  submissionReason[submission.projectId],
+                                )
+                              }
+                              className="flex-1 px-3 py-2 bg-red-500/10 text-red-600 hover:bg-red-500 hover:text-white rounded-xl text-sm font-bold"
+                            >
+                              Reject
+                            </button>
+                            {submission.status !== "flagged" && (
+                              <button
+                                onClick={() =>
+                                  handleSubmissionAction(
+                                    submission.projectId,
+                                    "flagged",
+                                    submissionReason[submission.projectId],
+                                  )
+                                }
+                                className="flex-1 px-3 py-2 bg-orange-500/10 text-orange-600 hover:bg-orange-500 hover:text-white rounded-xl text-sm font-bold"
+                              >
+                                Flag
+                              </button>
+                            )}
+                          </div>
+                        </div>
+                      )}
+                    </div>
+                  </div>
+                ))}
+              </div>
+            )}
           </div>
         )}
 

--- a/dongle/app/discover/page.tsx
+++ b/dongle/app/discover/page.tsx
@@ -46,7 +46,7 @@ function DiscoverContent() {
   // Fetch verification statuses for all projects
   useEffect(() => {
     const fetchVerificationStatuses = async () => {
-      const projects = projectService.getAllProjects();
+      const projects = projectService.getDiscoverableProjects();
       const statuses: Record<string, VerificationStatus> = {};
       
       await Promise.all(
@@ -73,7 +73,7 @@ function DiscoverContent() {
   const filteredAndSortedProjects = useMemo(() => {
     let result = searchQuery
       ? projectService.searchProjects(searchQuery)
-      : projectService.getAllProjects();
+      : projectService.getDiscoverableProjects();
 
     if (category !== "All") {
       result = result.filter((p) => p.primaryCategory === category);

--- a/dongle/app/profile/page.tsx
+++ b/dongle/app/profile/page.tsx
@@ -15,6 +15,7 @@ import WalletStatePanel, {
 } from "@/components/wallet/WalletStatePanel";
 import { useWalletPageGate } from "@/hooks/useWalletPageGate";
 import { useStellarAccount } from "@/hooks/useStellarAccount";
+import { useWalletTransactions } from "@/hooks/useWalletTransactions";
 import { EXPECTED_NETWORK_LABEL } from "@/context/wallet.context";
 import {
   LogOut,
@@ -27,6 +28,8 @@ import {
   XCircle,
   Package,
   Bookmark,
+  Activity,
+  Wallet,
 } from "lucide-react";
 import AddressDisplay from "@/components/ui/AddressDisplay";
 import { formatDate } from "@/lib/date";
@@ -49,7 +52,8 @@ const PROFILE_PURPOSE =
 export default function ProfilePage() {
   const router = useRouter();
   const gate = useWalletPageGate({ requireFundedAccount: true });
-  const { balances } = useStellarAccount();
+  const { balances, loading: balancesLoading, error: balancesError } = useStellarAccount();
+  const { transactions, loading: txLoading, error: txError } = useWalletTransactions(8);
   const confirm = useConfirm();
   const { recentProjects, clearHistory, hasHistory } = useRecentViews(gate.publicKey || undefined);
   const { savedProjectIds } = useSavedProjects();
@@ -64,6 +68,9 @@ export default function ProfilePage() {
   const savedProjects = savedProjectIds
     .map((projectId) => projectService.getProjectById(projectId))
     .filter((project): project is NonNullable<typeof project> => Boolean(project));
+  const ownedProjects = gate.publicKey
+    ? projectService.getProjectsByOwner(gate.publicKey)
+    : [];
 
   // Fetch verification statuses for saved projects
   useEffect(() => {
@@ -241,7 +248,15 @@ export default function ProfilePage() {
                   </div>
                 </div>
 
-                {balances && balances.length > 0 && (
+                {balancesLoading ? (
+                  <div className="flex justify-center py-6">
+                    <Spinner size="md" />
+                  </div>
+                ) : balancesError ? (
+                  <div className="p-4 bg-red-50 dark:bg-red-900/20 rounded-2xl text-sm text-red-600 dark:text-red-400">
+                    {balancesError}
+                  </div>
+                ) : balances && balances.length > 0 ? (
                   <div>
                     <label className="text-sm font-medium text-zinc-500 dark:text-zinc-400 mb-4 block">
                       Balances
@@ -279,6 +294,79 @@ export default function ProfilePage() {
                         );
                       })}
                     </div>
+                  </div>
+                ) : (
+                  <p className="text-sm text-zinc-500 dark:text-zinc-400">
+                    No balances found for this account.
+                  </p>
+                )}
+              </div>
+
+              <div className="bg-white dark:bg-zinc-900 border border-zinc-200 dark:border-zinc-800 rounded-3xl p-8">
+                <div className="flex items-center justify-between mb-6">
+                  <h2 className="text-2xl font-bold flex items-center gap-2">
+                    <Activity className="w-6 h-6" />
+                    Recent Wallet Activity
+                  </h2>
+                  <Badge variant="secondary">{transactions.length}</Badge>
+                </div>
+
+                {txLoading ? (
+                  <div className="flex justify-center py-8">
+                    <Spinner size="md" />
+                  </div>
+                ) : txError ? (
+                  <div className="p-4 bg-red-50 dark:bg-red-900/20 rounded-2xl text-sm text-red-600 dark:text-red-400">
+                    {txError}
+                  </div>
+                ) : transactions.length > 0 ? (
+                  <div className="space-y-3">
+                    {transactions.map((tx) => (
+                      <div
+                        key={tx.id}
+                        className="flex items-center justify-between p-4 bg-zinc-50 dark:bg-zinc-800 rounded-2xl"
+                      >
+                        <div>
+                          <p className="font-medium text-zinc-900 dark:text-zinc-100 capitalize">
+                            {tx.type.replace(/_/g, " ")}
+                          </p>
+                          <p className="text-xs text-zinc-500 dark:text-zinc-400">
+                            {formatDate(tx.createdAt, "relative")}
+                          </p>
+                        </div>
+                        <p className="text-xs font-mono text-zinc-500 truncate max-w-[120px]">
+                          {tx.hash.slice(0, 8)}…
+                        </p>
+                      </div>
+                    ))}
+                  </div>
+                ) : (
+                  <div className="text-center py-8 text-zinc-500 dark:text-zinc-400">
+                    <Wallet className="w-10 h-10 mx-auto mb-2 opacity-50" />
+                    <p className="text-sm">No recent on-chain activity found.</p>
+                  </div>
+                )}
+              </div>
+
+              <div className="bg-white dark:bg-zinc-900 border border-zinc-200 dark:border-zinc-800 rounded-3xl p-8">
+                <div className="flex items-center justify-between mb-6">
+                  <h2 className="text-2xl font-bold flex items-center gap-2">
+                    <Package className="w-6 h-6" />
+                    Your Projects
+                  </h2>
+                  <Badge variant="secondary">{ownedProjects.length}</Badge>
+                </div>
+
+                {ownedProjects.length > 0 ? (
+                  <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+                    {ownedProjects.map((project) => (
+                      <ProjectCard key={project.id} project={project} />
+                    ))}
+                  </div>
+                ) : (
+                  <div className="text-center py-8 text-zinc-500 dark:text-zinc-400">
+                    <Package className="w-10 h-10 mx-auto mb-2 opacity-50" />
+                    <p className="text-sm">No owned projects found for this wallet.</p>
                   </div>
                 )}
               </div>
@@ -507,8 +595,29 @@ export default function ProfilePage() {
                   </div>
                   <div className="flex justify-between items-center">
                     <span className="text-zinc-500 dark:text-zinc-400 flex items-center gap-2">
+                      <Bookmark className="w-4 h-4" />
+                      Saved
+                    </span>
+                    <span className="font-bold text-lg">{savedProjects.length}</span>
+                  </div>
+                  <div className="flex justify-between items-center">
+                    <span className="text-zinc-500 dark:text-zinc-400 flex items-center gap-2">
                       <Package className="w-4 h-4" />
-                      Submitted
+                      Owned
+                    </span>
+                    <span className="font-bold text-lg">{ownedProjects.length}</span>
+                  </div>
+                  <div className="flex justify-between items-center">
+                    <span className="text-zinc-500 dark:text-zinc-400 flex items-center gap-2">
+                      <Activity className="w-4 h-4" />
+                      Transactions
+                    </span>
+                    <span className="font-bold text-lg">{transactions.length}</span>
+                  </div>
+                  <div className="flex justify-between items-center">
+                    <span className="text-zinc-500 dark:text-zinc-400 flex items-center gap-2">
+                      <Package className="w-4 h-4" />
+                      Verifications
                     </span>
                     <span className="font-bold text-lg">{displayedVerificationRequests.length}</span>
                   </div>

--- a/dongle/app/projects/[id]/page.tsx
+++ b/dongle/app/projects/[id]/page.tsx
@@ -11,6 +11,10 @@ import { Spinner } from "@/components/ui/Spinner";
 import VerificationStatus from "@/components/verify/VerificationStatus";
 import ReviewList from "@/components/reviews/ReviewList";
 import ReviewForm from "@/components/reviews/ReviewForm";
+import {
+  RatingDistributionSummary,
+  computeRatingDistribution,
+} from "@/components/reviews/RatingDistributionSummary";
 import ProjectImage from "@/components/projects/ProjectImage";
 import { RepositoryMetadata } from "@/components/projects/RepositoryMetadata";
 import { Review,
@@ -278,15 +282,10 @@ export default function ProjectDetailPage() {
     setReportingReview(null);
   };
 
-  const ratingDistribution = React.useMemo(() => {
-    const dist = { 5: 0, 4: 0, 3: 0, 2: 0, 1: 0 };
-    reviews.forEach((r) => {
-      if (r.rating >= 1 && r.rating <= 5) {
-        dist[r.rating as keyof typeof dist]++;
-      }
-    });
-    return dist;
-  }, [reviews]);
+  const ratingDistribution = React.useMemo(
+    () => computeRatingDistribution(reviews),
+    [reviews],
+  );
 
   const sortedReviews = React.useMemo(() => {
     let list = [...reviews];
@@ -811,38 +810,12 @@ export default function ProjectDetailPage() {
                   </div>
                 </div>
 
-                {reviews.length > 0 && (
-                  <div className="mb-8 p-6 bg-zinc-50 dark:bg-zinc-800/50 rounded-2xl border border-zinc-200 dark:border-zinc-800 flex flex-col md:flex-row gap-8 items-center">
-                    <div className="text-center md:text-left">
-                      <div className="text-5xl font-black mb-1">{actualRating}</div>
-                      <div className="flex items-center justify-center md:justify-start gap-1 mb-2">
-                        {[1, 2, 3, 4, 5].map((star) => (
-                          <Star key={star} className={`w-4 h-4 ${star <= actualRating ? 'text-yellow-500 fill-yellow-500' : 'text-zinc-300 dark:text-zinc-700'}`} />
-                        ))}
-                      </div>
-                      <div className="text-sm text-zinc-500 dark:text-zinc-400">{reviews.length} total reviews</div>
-                    </div>
-                    <div className="flex-1 w-full max-w-sm space-y-2">
-                      {[5, 4, 3, 2, 1].map((star) => {
-                        const count = ratingDistribution[star as keyof typeof ratingDistribution];
-                        const percentage = reviews.length > 0 ? Math.round((count / reviews.length) * 100) : 0;
-                        return (
-                          <div key={star} className="flex items-center gap-3 text-sm">
-                            <div className="w-12 text-zinc-500 dark:text-zinc-400 font-medium flex items-center gap-1">
-                              {star} <Star className="w-3 h-3" />
-                            </div>
-                            <div className="flex-1 h-2.5 bg-zinc-200 dark:bg-zinc-700 rounded-full overflow-hidden">
-                              <div className="h-full bg-yellow-500 rounded-full" style={{ width: `${percentage}%` }} />
-                            </div>
-                            <div className="w-10 text-right text-zinc-500 dark:text-zinc-400">
-                              {percentage}%
-                            </div>
-                          </div>
-                        );
-                      })}
-                    </div>
-                  </div>
-                )}
+                <RatingDistributionSummary
+                  distribution={ratingDistribution}
+                  totalReviews={reviews.length}
+                  averageRating={actualRating}
+                  className="mb-8"
+                />
 
                 {isOwner && (
                   <div className="mb-6 p-4 bg-blue-50 dark:bg-blue-900/20 text-blue-700 dark:text-blue-400 rounded-xl border border-blue-100 dark:border-blue-900/50 text-sm flex items-start gap-3">

--- a/dongle/components/projects/ProjectForm.tsx
+++ b/dongle/components/projects/ProjectForm.tsx
@@ -10,6 +10,10 @@ import { TextAreaField } from "@/components/ui/TextAreaField";
 import { TagInput } from "@/components/ui/TagInput";
 import { sorobanService } from "@/services/stellar/soroban.service";
 import { projectService } from "@/services/project/project.service";
+import { projectSubmissionService } from "@/services/project/project-submission.service";
+import { walletService } from "@/services/wallet/wallet.service";
+import { generateProjectIdFromName } from "@/lib/project-id";
+import { computeQualityScore, detectSuspiciousFlags } from "@/lib/submission-quality";
 import { Rocket, CheckCircle2, Plus, X } from "lucide-react";
 import { useRouter } from "next/navigation";
 import TransactionProgressPanel from "@/components/transactions/TransactionProgressPanel";
@@ -225,6 +229,37 @@ export default function ProjectForm({
         });
 
         if (result) {
+          if (mode !== "edit") {
+            try {
+              let submittedBy = "unknown";
+              try {
+                submittedBy = await walletService.getPublicKey();
+              } catch {
+                // wallet may disconnect after tx
+              }
+
+              const qualityScore = computeQualityScore(cleanedPayload);
+              const existingNames = projectService
+                .getAllProjects()
+                .map((p) => p.name);
+              const flagReasons = detectSuspiciousFlags(
+                cleanedPayload,
+                qualityScore,
+                existingNames,
+              );
+
+              projectSubmissionService.recordSubmission({
+                projectId: generateProjectIdFromName(cleanedPayload.name),
+                projectName: cleanedPayload.name,
+                submittedBy,
+                qualityScore,
+                flagReasons,
+              });
+            } catch (moderationError) {
+              console.error("[ProjectForm] Failed to record submission moderation:", moderationError);
+            }
+          }
+
           trackProjectSubmit({
             success: true,
             mode,

--- a/dongle/components/reviews/RatingDistributionSummary.tsx
+++ b/dongle/components/reviews/RatingDistributionSummary.tsx
@@ -1,0 +1,101 @@
+"use client";
+
+import React from "react";
+import { Star } from "lucide-react";
+
+export type RatingDistribution = Record<1 | 2 | 3 | 4 | 5, number>;
+
+interface RatingDistributionSummaryProps {
+  distribution: RatingDistribution;
+  totalReviews: number;
+  averageRating: number;
+  className?: string;
+}
+
+export function computeRatingDistribution(
+  reviews: { rating: number }[],
+): RatingDistribution {
+  const dist: RatingDistribution = { 5: 0, 4: 0, 3: 0, 2: 0, 1: 0 };
+  reviews.forEach((r) => {
+    if (r.rating >= 1 && r.rating <= 5) {
+      dist[r.rating as keyof RatingDistribution]++;
+    }
+  });
+  return dist;
+}
+
+export function RatingDistributionSummary({
+  distribution,
+  totalReviews,
+  averageRating,
+  className = "",
+}: RatingDistributionSummaryProps) {
+  if (totalReviews === 0) {
+    return (
+      <div
+        className={`p-6 bg-zinc-50 dark:bg-zinc-800/50 rounded-2xl border border-zinc-200 dark:border-zinc-800 text-center ${className}`}
+      >
+        <p className="text-sm text-zinc-500 dark:text-zinc-400">
+          No reviews yet — rating distribution will appear once users leave feedback.
+        </p>
+      </div>
+    );
+  }
+
+  const displayRating = Number.isFinite(averageRating)
+    ? averageRating.toFixed(1)
+    : "0.0";
+
+  return (
+    <div
+      className={`p-6 bg-zinc-50 dark:bg-zinc-800/50 rounded-2xl border border-zinc-200 dark:border-zinc-800 flex flex-col md:flex-row gap-8 items-center ${className}`}
+    >
+      <div className="text-center md:text-left">
+        <div className="text-5xl font-black mb-1">{displayRating}</div>
+        <div className="flex items-center justify-center md:justify-start gap-1 mb-2">
+          {[1, 2, 3, 4, 5].map((star) => (
+            <Star
+              key={star}
+              className={`w-4 h-4 ${
+                star <= Math.round(averageRating)
+                  ? "text-yellow-500 fill-yellow-500"
+                  : "text-zinc-300 dark:text-zinc-700"
+              }`}
+            />
+          ))}
+        </div>
+        <div className="text-sm text-zinc-500 dark:text-zinc-400">
+          {totalReviews} total review{totalReviews !== 1 ? "s" : ""}
+        </div>
+      </div>
+      <div className="flex-1 w-full max-w-sm space-y-2">
+        {([5, 4, 3, 2, 1] as const).map((star) => {
+          const count = distribution[star];
+          const percentage =
+            totalReviews > 0 ? Math.round((count / totalReviews) * 100) : 0;
+          return (
+            <div key={star} className="flex items-center gap-3 text-sm">
+              <div className="w-12 text-zinc-500 dark:text-zinc-400 font-medium flex items-center gap-1">
+                {star} <Star className="w-3 h-3" />
+              </div>
+              <div className="flex-1 h-2.5 bg-zinc-200 dark:bg-zinc-700 rounded-full overflow-hidden">
+                <div
+                  className="h-full bg-yellow-500 rounded-full transition-all duration-300"
+                  style={{ width: `${percentage}%` }}
+                  role="progressbar"
+                  aria-valuenow={percentage}
+                  aria-valuemin={0}
+                  aria-valuemax={100}
+                  aria-label={`${star} star ratings: ${percentage}%`}
+                />
+              </div>
+              <div className="w-16 text-right text-zinc-500 dark:text-zinc-400 tabular-nums">
+                {count} ({percentage}%)
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/dongle/components/verify/VerificationStatus.tsx
+++ b/dongle/components/verify/VerificationStatus.tsx
@@ -4,7 +4,7 @@ import React, { useState } from "react";
 import { Card } from "@/components/ui/Card";
 import { Badge } from "@/components/ui/Badge";
 import { sorobanService } from "@/services/stellar/soroban.service";
-import { Loader2, Search, CheckCircle2, Clock, XCircle, AlertCircle } from "lucide-react";
+import { Loader2, Search, CheckCircle2, Clock, XCircle, AlertCircle, HelpCircle } from "lucide-react";
 import { FormField } from "@/components/ui/FormField";
 import { Button } from "@/components/ui/Button";
 
@@ -14,25 +14,38 @@ interface VerificationStatusProps {
   initialProjectId?: string;
 }
 
+type LookupState = {
+  status: Status;
+  projectExists: boolean;
+  requestExists: boolean;
+  rejectionReason?: string;
+};
+
 export default function VerificationStatus({ initialProjectId }: VerificationStatusProps) {
   const [projectId, setProjectId] = useState(initialProjectId ?? "");
   const [searchInput, setSearchInput] = useState(initialProjectId ?? "");
-  const [status, setStatus] = useState<Status>("NONE");
+  const [lookup, setLookup] = useState<LookupState | null>(null);
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
   const isMountedRef = React.useRef(true);
 
-  const fetchStatus = async (id: string) => {
+  const fetchStatus = async (id: string, signal?: AbortSignal) => {
     if (!id) return;
     setIsLoading(true);
     setError(null);
     try {
-      const result = await sorobanService.getVerificationStatus(id);
+      const result = await sorobanService.getVerificationRequestStatus(id, signal);
       if (!isMountedRef.current) return;
-      setStatus(result);
+      setLookup({
+        status: result.status,
+        projectExists: result.projectExists,
+        requestExists: result.requestExists,
+        rejectionReason: result.rejectionReason,
+      });
     } catch (err) {
       if (!isMountedRef.current) return;
+      if (err instanceof DOMException && err.name === "AbortError") return;
       const msg = err instanceof Error ? err.message : "Failed to check verification status";
       console.error(err);
       setError(msg);
@@ -45,11 +58,13 @@ export default function VerificationStatus({ initialProjectId }: VerificationSta
 
   React.useEffect(() => {
     isMountedRef.current = true;
+    const controller = new AbortController();
     if (initialProjectId) {
-      void (async () => { await fetchStatus(initialProjectId); })();
+      void fetchStatus(initialProjectId, controller.signal);
     }
     return () => {
       isMountedRef.current = false;
+      controller.abort();
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
@@ -57,41 +72,88 @@ export default function VerificationStatus({ initialProjectId }: VerificationSta
   const handleSearch = (e: React.FormEvent) => {
     e.preventDefault();
     setProjectId(searchInput);
-    fetchStatus(searchInput);
+    void fetchStatus(searchInput);
   };
 
-  const statusConfig = {
-    NONE: {
-      icon: <AlertCircle className="w-12 h-12 text-zinc-400" />,
-      title: "Not Found",
-      description: "No verification request found for this project.",
-      color: "border-zinc-200 dark:border-zinc-800",
-      badge: "outline" as const
-    },
-    PENDING: {
-      icon: <Clock className="w-12 h-12 text-yellow-500" />,
-      title: "Pending Review",
-      description: "The verification request is currently being reviewed by the community.",
-      color: "border-yellow-500/50 bg-yellow-500/5",
-      badge: "warning" as const
-    },
-    VERIFIED: {
-      icon: <CheckCircle2 className="w-12 h-12 text-green-500" />,
-      title: "Verified",
-      description: "This project has been verified and is considered trustworthy.",
-      color: "border-green-500/50 bg-green-500/5",
-      badge: "success" as const
-    },
-    REJECTED: {
-      icon: <XCircle className="w-12 h-12 text-red-500" />,
-      title: "Rejected",
-      description: "The verification request for this project was rejected.",
-      color: "border-red-500/50 bg-red-500/5",
-      badge: "error" as const
+  const resolveDisplay = (): {
+    icon: React.ReactNode;
+    title: string;
+    description: string;
+    color: string;
+    badge: "outline" | "warning" | "success" | "error";
+    badgeLabel: string;
+  } => {
+    if (!lookup) {
+      return {
+        icon: <HelpCircle className="w-12 h-12 text-zinc-400" />,
+        title: "Search",
+        description: "Enter a project ID to check verification status.",
+        color: "border-zinc-200 dark:border-zinc-800",
+        badge: "outline",
+        badgeLabel: "NONE",
+      };
     }
+
+    if (!lookup.projectExists) {
+      return {
+        icon: <HelpCircle className="w-12 h-12 text-zinc-400" />,
+        title: "Project Not Found",
+        description: "This project ID is not registered in the directory.",
+        color: "border-zinc-200 dark:border-zinc-800",
+        badge: "outline",
+        badgeLabel: "UNKNOWN",
+      };
+    }
+
+    if (!lookup.requestExists) {
+      return {
+        icon: <AlertCircle className="w-12 h-12 text-zinc-400" />,
+        title: "No Verification Request",
+        description: "This project exists but has not submitted a verification request.",
+        color: "border-zinc-200 dark:border-zinc-800",
+        badge: "outline",
+        badgeLabel: "NONE",
+      };
+    }
+
+    const statusConfig = {
+      PENDING: {
+        icon: <Clock className="w-12 h-12 text-yellow-500" />,
+        title: "Pending Review",
+        description: "The verification request is currently being reviewed by the community.",
+        color: "border-yellow-500/50 bg-yellow-500/5",
+        badge: "warning" as const,
+      },
+      VERIFIED: {
+        icon: <CheckCircle2 className="w-12 h-12 text-green-500" />,
+        title: "Verified",
+        description: "This project has been verified and is considered trustworthy.",
+        color: "border-green-500/50 bg-green-500/5",
+        badge: "success" as const,
+      },
+      REJECTED: {
+        icon: <XCircle className="w-12 h-12 text-red-500" />,
+        title: "Rejected",
+        description: lookup.rejectionReason
+          ? `Verification was rejected: ${lookup.rejectionReason}`
+          : "The verification request for this project was rejected.",
+        color: "border-red-500/50 bg-red-500/5",
+        badge: "error" as const,
+      },
+      NONE: {
+        icon: <AlertCircle className="w-12 h-12 text-zinc-400" />,
+        title: "No Verification Request",
+        description: "This project exists but has not submitted a verification request.",
+        color: "border-zinc-200 dark:border-zinc-800",
+        badge: "outline" as const,
+      },
+    };
+
+    const config = statusConfig[lookup.status];
+    return { ...config, badgeLabel: lookup.status };
   };
 
-  const config = statusConfig[status];
+  const display = resolveDisplay();
 
   return (
     <div className="w-full max-w-lg mx-auto space-y-6 animate-fade-in">
@@ -129,20 +191,20 @@ export default function VerificationStatus({ initialProjectId }: VerificationSta
       )}
 
       {projectId && !error && (
-        <Card className={`transition-all duration-300 border-2 ${config.color}`} padding="lg">
+        <Card className={`transition-all duration-300 border-2 ${display.color}`} padding="lg">
           <div className="flex flex-col items-center text-center gap-4">
             {isLoading ? (
               <Loader2 className="w-12 h-12 text-blue-500 animate-spin" />
             ) : (
-              config.icon
+              display.icon
             )}
-            
+
             {!isLoading && (
               <>
-                <Badge variant={config.badge}>{status}</Badge>
-                <h3 className="text-xl font-bold">{config.title}</h3>
+                <Badge variant={display.badge}>{display.badgeLabel}</Badge>
+                <h3 className="text-xl font-bold">{display.title}</h3>
                 <p className="text-zinc-500 dark:text-zinc-400 text-sm">
-                  {config.description}
+                  {display.description}
                 </p>
                 <div className="mt-4 p-3 bg-zinc-100 dark:bg-zinc-900 rounded-xl w-full">
                   <p className="text-xs font-mono text-zinc-500 truncate">

--- a/dongle/hooks/useWalletTransactions.ts
+++ b/dongle/hooks/useWalletTransactions.ts
@@ -1,0 +1,88 @@
+"use client";
+
+import { useState, useEffect, useCallback, useRef } from "react";
+import { useWallet } from "@/context/wallet.context";
+
+export interface WalletTransaction {
+  id: string;
+  hash: string;
+  createdAt: string;
+  type: string;
+  sourceAccount: string;
+}
+
+interface UseWalletTransactionsReturn {
+  transactions: WalletTransaction[];
+  loading: boolean;
+  error: string | null;
+  refetch: () => Promise<void>;
+}
+
+function mapHorizonTransaction(record: {
+  id: string;
+  hash?: string;
+  created_at: string;
+  type?: string;
+  source_account?: string;
+}): WalletTransaction {
+  return {
+    id: record.id,
+    hash: record.hash ?? record.id,
+    createdAt: record.created_at,
+    type: record.type ?? "unknown",
+    sourceAccount: record.source_account ?? "",
+  };
+}
+
+export function useWalletTransactions(limit = 10): UseWalletTransactionsReturn {
+  const { publicKey, isConnected } = useWallet();
+  const [transactions, setTransactions] = useState<WalletTransaction[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const isMountedRef = useRef(true);
+
+  useEffect(() => {
+    isMountedRef.current = true;
+    return () => {
+      isMountedRef.current = false;
+    };
+  }, []);
+
+  const fetchTransactions = useCallback(async () => {
+    if (!publicKey || !isConnected) {
+      if (isMountedRef.current) {
+        setTransactions([]);
+        setError(null);
+      }
+      return;
+    }
+
+    setLoading(true);
+    setError(null);
+
+    try {
+      const { stellarService } = await import(
+        /* webpackChunkName: "stellar-service" */ "@/services/stellar/stellar.service"
+      );
+      const records = await stellarService.getTransactions(publicKey, limit);
+      if (!isMountedRef.current) return;
+      setTransactions(records.map(mapHorizonTransaction));
+    } catch (err) {
+      if (!isMountedRef.current) return;
+      const msg =
+        err instanceof Error ? err.message : "Failed to fetch wallet activity";
+      setError(msg);
+      setTransactions([]);
+    } finally {
+      if (isMountedRef.current) {
+        setLoading(false);
+      }
+    }
+  }, [publicKey, isConnected, limit]);
+
+  useEffect(() => {
+    void fetchTransactions();
+  }, [fetchTransactions]);
+
+  return { transactions, loading, error, refetch: fetchTransactions };
+}

--- a/dongle/lib/project-id.ts
+++ b/dongle/lib/project-id.ts
@@ -1,0 +1,12 @@
+/**
+ * Generates a URL-safe project ID slug from a project name.
+ */
+export function generateProjectIdFromName(name: string): string {
+  const slug = name
+    .toLowerCase()
+    .trim()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+
+  return slug || `project-${Date.now()}`;
+}

--- a/dongle/lib/submission-quality.ts
+++ b/dongle/lib/submission-quality.ts
@@ -1,0 +1,74 @@
+export interface SubmissionChecklistInput {
+  name?: string;
+  description?: string;
+  websiteUrl?: string;
+  githubUrl?: string;
+  logoUrl?: string;
+  docsUrl?: string;
+  auditReportUrl?: string;
+  bugBountyUrl?: string;
+  contractAddresses?: string[];
+}
+
+/**
+ * Computes submission quality score (0–100) from form field completeness.
+ * Mirrors the weighting used by SubmissionChecklist.
+ */
+export function computeQualityScore(formData: SubmissionChecklistInput): number {
+  const required = [
+    Boolean(formData.name?.trim()),
+    Boolean(formData.description?.trim()),
+    Boolean(formData.websiteUrl?.trim()),
+    Boolean(formData.githubUrl?.trim()),
+  ];
+  const optional = [
+    Boolean(formData.logoUrl?.trim()),
+    Boolean(formData.docsUrl?.trim()),
+    Boolean(formData.auditReportUrl?.trim()),
+    Boolean(formData.bugBountyUrl?.trim()),
+    Boolean(formData.contractAddresses?.some((a) => a.trim().length > 0)),
+  ];
+
+  const requiredCompleted = required.filter(Boolean).length;
+  const optionalCompleted = optional.filter(Boolean).length;
+
+  const requiredWeight = 0.6;
+  const optionalWeight = 0.4;
+  const requiredScore = required.length > 0 ? requiredCompleted / required.length : 1;
+  const optionalScore = optional.length > 0 ? optionalCompleted / optional.length : 0;
+
+  return Math.round((requiredScore * requiredWeight + optionalScore * optionalWeight) * 100);
+}
+
+export function detectSuspiciousFlags(
+  formData: SubmissionChecklistInput,
+  qualityScore: number,
+  existingNames: string[],
+): string[] {
+  const flags: string[] = [];
+
+  if (qualityScore < 40) {
+    flags.push("Low quality score");
+  }
+
+  if (!formData.auditReportUrl?.trim()) {
+    flags.push("No audit report provided");
+  }
+
+  const normName = (formData.name ?? "").toLowerCase().trim();
+  if (normName && existingNames.some((n) => n.toLowerCase().trim() === normName)) {
+    flags.push("Possible duplicate project name");
+  }
+
+  const desc = formData.description ?? "";
+  if (desc.length < 30) {
+    flags.push("Very short description");
+  }
+
+  const urlPattern = /(bit\.ly|tinyurl|t\.co|goo\.gl)/i;
+  if (urlPattern.test(formData.websiteUrl ?? "")) {
+    flags.push("Suspicious shortened URL");
+  }
+
+  return flags;
+}

--- a/dongle/services/project/project-submission.service.ts
+++ b/dongle/services/project/project-submission.service.ts
@@ -1,0 +1,172 @@
+import { generateId } from "@/lib/id-generator";
+import { nowUTC } from "@/lib/date";
+import {
+  ProjectSubmission,
+  ProjectSubmissionModerationAction,
+  ProjectSubmissionModerationStatus,
+} from "@/types/project";
+
+const STORAGE_KEY = "dongle_project_submissions";
+const MODERATION_LOG_KEY = "dongle_submission_moderation_log";
+
+function loadSubmissions(): ProjectSubmission[] {
+  if (typeof window === "undefined") return [];
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return [];
+    const parsed = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return [];
+    return parsed.filter(
+      (item): item is ProjectSubmission =>
+        item &&
+        typeof item === "object" &&
+        typeof item.id === "string" &&
+        typeof item.projectId === "string" &&
+        typeof item.status === "string",
+    );
+  } catch {
+    return [];
+  }
+}
+
+function saveSubmissions(submissions: ProjectSubmission[]): void {
+  if (typeof window === "undefined") return;
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(submissions));
+}
+
+function loadModerationLog(): ProjectSubmissionModerationAction[] {
+  if (typeof window === "undefined") return [];
+  try {
+    const raw = localStorage.getItem(MODERATION_LOG_KEY);
+    if (!raw) return [];
+    const parsed = JSON.parse(raw);
+    return Array.isArray(parsed) ? parsed : [];
+  } catch {
+    return [];
+  }
+}
+
+function saveModerationLog(log: ProjectSubmissionModerationAction[]): void {
+  if (typeof window === "undefined") return;
+  localStorage.setItem(MODERATION_LOG_KEY, JSON.stringify(log));
+}
+
+function deriveInitialStatus(
+  flagReasons: string[],
+): ProjectSubmissionModerationStatus {
+  if (flagReasons.length >= 2) return "flagged";
+  if (flagReasons.length === 1) return "pending";
+  return "approved";
+}
+
+export const projectSubmissionService = {
+  recordSubmission(input: {
+    projectId: string;
+    projectName: string;
+    submittedBy: string;
+    qualityScore: number;
+    flagReasons: string[];
+  }): ProjectSubmission {
+    const submissions = loadSubmissions();
+    const existing = submissions.find((s) => s.projectId === input.projectId);
+
+    const status = deriveInitialStatus(input.flagReasons);
+    const submission: ProjectSubmission = {
+      id: existing?.id ?? generateId(),
+      projectId: input.projectId,
+      projectName: input.projectName,
+      submittedBy: input.submittedBy,
+      submittedAt: existing?.submittedAt ?? nowUTC(),
+      status,
+      qualityScore: input.qualityScore,
+      flagReasons: input.flagReasons,
+      statusUpdatedAt: nowUTC(),
+    };
+
+    const index = submissions.findIndex((s) => s.projectId === input.projectId);
+    if (index >= 0) {
+      submissions[index] = submission;
+    } else {
+      submissions.push(submission);
+    }
+    saveSubmissions(submissions);
+    return submission;
+  },
+
+  getSubmissionByProjectId(projectId: string): ProjectSubmission | null {
+    return loadSubmissions().find((s) => s.projectId === projectId) ?? null;
+  },
+
+  getSubmissionsByUser(submittedBy: string): ProjectSubmission[] {
+    return loadSubmissions()
+      .filter((s) => s.submittedBy === submittedBy)
+      .sort(
+        (a, b) =>
+          new Date(b.submittedAt).getTime() - new Date(a.submittedAt).getTime(),
+      );
+  },
+
+  getAllSubmissions(): ProjectSubmission[] {
+    return loadSubmissions().sort(
+      (a, b) =>
+        new Date(b.submittedAt).getTime() - new Date(a.submittedAt).getTime(),
+    );
+  },
+
+  getQueue(): ProjectSubmission[] {
+    return loadSubmissions()
+      .filter((s) => s.status === "pending" || s.status === "flagged")
+      .sort(
+        (a, b) =>
+          new Date(b.submittedAt).getTime() - new Date(a.submittedAt).getTime(),
+      );
+  },
+
+  isDiscoverable(projectId: string): boolean {
+    const submission = this.getSubmissionByProjectId(projectId);
+    if (!submission) return true;
+    return submission.status === "approved";
+  },
+
+  updateStatus(
+    projectId: string,
+    status: ProjectSubmissionModerationStatus,
+    moderatorAddress: string,
+    reason?: string,
+  ): { success: boolean; error?: string; submission?: ProjectSubmission } {
+    const submissions = loadSubmissions();
+    const index = submissions.findIndex((s) => s.projectId === projectId);
+    if (index < 0) {
+      return { success: false, error: "Submission not found" };
+    }
+
+    const submission = submissions[index];
+    submission.status = status;
+    submission.statusUpdatedAt = nowUTC();
+    submission.statusUpdatedBy = moderatorAddress;
+    if (reason) {
+      submission.rejectionReason = reason;
+    }
+
+    submissions[index] = submission;
+    saveSubmissions(submissions);
+
+    const log = loadModerationLog();
+    log.unshift({
+      id: generateId(),
+      submissionId: submission.id,
+      projectId,
+      moderatorAddress,
+      action: status,
+      reason: reason ?? `Status updated to ${status}`,
+      timestamp: nowUTC(),
+    });
+    saveModerationLog(log);
+
+    return { success: true, submission };
+  },
+
+  getModerationLog(): ProjectSubmissionModerationAction[] {
+    return loadModerationLog();
+  },
+};

--- a/dongle/services/project/project.service.ts
+++ b/dongle/services/project/project.service.ts
@@ -1,6 +1,7 @@
 import { mockProjects } from "@/data/mockProjects";
 import { Project } from "@/types/project";
 import { projectOwnerService } from "./project-owner.service";
+import { projectSubmissionService } from "./project-submission.service";
 import { registry } from "@/services/data-access/registry";
 
 /**
@@ -59,11 +60,30 @@ export const projectService = {
   },
 
   /**
+   * Get projects owned by a wallet address
+   */
+  getProjectsByOwner(ownerAddress: string): Project[] {
+    const normalized = ownerAddress.trim();
+    return this.getAllProjects().filter(
+      (p) => p.ownerAddress?.trim() === normalized,
+    );
+  },
+
+  /**
+   * Get projects discoverable in the directory (excludes moderated-out submissions)
+   */
+  getDiscoverableProjects(): Project[] {
+    return this.getAllProjects().filter((p) =>
+      projectSubmissionService.isDiscoverable(p.id),
+    );
+  },
+
+  /**
    * Search projects by name or description
    */
   searchProjects(query: string): Project[] {
     const q = query.toLowerCase();
-    return this.getAllProjects().filter(
+    return this.getDiscoverableProjects().filter(
       (p) =>
         p.name.toLowerCase().includes(q) ||
         p.description.toLowerCase().includes(q) ||

--- a/dongle/services/stellar/soroban.service.ts
+++ b/dongle/services/stellar/soroban.service.ts
@@ -310,20 +310,64 @@ export const sorobanService = {
     projectId: string,
     signal?: AbortSignal,
   ): Promise<"NONE" | "PENDING" | "VERIFIED" | "REJECTED"> {
+    if (signal?.aborted) {
+      throw new DOMException("Aborted", "AbortError");
+    }
+
     try {
       const { verificationService } = await import("./verification.service");
       const status = await verificationService.getVerificationStatus(projectId);
+
+      if (signal?.aborted) {
+        throw new DOMException("Aborted", "AbortError");
+      }
+
       console.log(
         `[SorobanService] Verification status for ${projectId}: ${status}`,
       );
       return status;
     } catch (error) {
+      if (error instanceof DOMException && error.name === "AbortError") {
+        throw error;
+      }
       console.error(
         "[SorobanService] Error getting verification status:",
         error,
       );
       return "NONE";
     }
+  },
+
+  /**
+   * Returns verification status with project/request context for UI distinction.
+   */
+  async getVerificationRequestStatus(
+    projectId: string,
+    signal?: AbortSignal,
+  ): Promise<{
+    projectExists: boolean;
+    requestExists: boolean;
+    status: "NONE" | "PENDING" | "VERIFIED" | "REJECTED";
+    rejectionReason?: string;
+  }> {
+    if (signal?.aborted) {
+      throw new DOMException("Aborted", "AbortError");
+    }
+
+    const { verificationService } = await import("./verification.service");
+    const result = await verificationService.getRequestStatus(projectId);
+
+    if (signal?.aborted) {
+      throw new DOMException("Aborted", "AbortError");
+    }
+
+    const status = result.request?.status ?? "NONE";
+    return {
+      projectExists: result.projectExists,
+      requestExists: result.requestExists,
+      status,
+      rejectionReason: result.request?.rejectionReason,
+    };
   },
 
   /**

--- a/dongle/services/stellar/verification.service.ts
+++ b/dongle/services/stellar/verification.service.ts
@@ -114,6 +114,22 @@ class VerificationService {
   }
 
   /**
+   * Gets all verification requests (for admin dashboard).
+   */
+  async getAllRequests(): Promise<VerificationRequest[]> {
+    try {
+      const requests = this.loadRequests();
+      return requests.sort(
+        (a, b) =>
+          new Date(b.submittedAt).getTime() - new Date(a.submittedAt).getTime(),
+      );
+    } catch (error) {
+      console.error("[VerificationService] Error getting all requests:", error);
+      return [];
+    }
+  }
+
+  /**
    * Gets all pending verification requests (for admin dashboard).
    */
   async getPendingRequests(): Promise<VerificationRequest[]> {
@@ -340,10 +356,12 @@ class VerificationService {
     request: VerificationRequest | null;
   }> {
     try {
+      const { projectService } = await import("../project/project.service");
+      const projectExists = projectService.getProjectById(projectId) !== null;
       const request = await this.getVerificationRequest(projectId);
-      
+
       return {
-        projectExists: true, // Would check against project registry in real implementation
+        projectExists,
         requestExists: request !== null,
         request,
       };

--- a/dongle/types/project.ts
+++ b/dongle/types/project.ts
@@ -175,6 +175,36 @@ export interface ProjectReportValidationError {
   message: string;
 }
 
+export type ProjectSubmissionModerationStatus =
+  | "pending"
+  | "approved"
+  | "rejected"
+  | "flagged";
+
+export interface ProjectSubmission {
+  id: string;
+  projectId: string;
+  projectName: string;
+  submittedBy: string;
+  submittedAt: string;
+  status: ProjectSubmissionModerationStatus;
+  qualityScore: number;
+  flagReasons: string[];
+  statusUpdatedAt?: string;
+  statusUpdatedBy?: string;
+  rejectionReason?: string;
+}
+
+export interface ProjectSubmissionModerationAction {
+  id: string;
+  submissionId: string;
+  projectId: string;
+  moderatorAddress: string;
+  action: ProjectSubmissionModerationStatus;
+  reason: string;
+  timestamp: string;
+}
+
 /**
  * Normalize a category string to canonical form
  * Handles various input formats and returns the canonical category


### PR DESCRIPTION




## #191 — Verification persistence

**Commit title:** `fix: persist verification requests and wire admin approval flow`

**PR description:**

### Summary
Verification requests and statuses are now fully backed by `verificationService` (localStorage) end-to-end. Admin approve/reject actions persist through the same service users submit to, and the status UI distinguishes unknown projects from projects without requests.

### Changes
- Extended `verificationService` with `getAllRequests()` and real project-existence checks via `projectService`
- Added `getVerificationRequestStatus()` to `soroban.service.ts` with `AbortSignal` support
- Rewired admin verification tab to load from `verificationService` instead of `MOCK_REQUESTS`
- Admin approve/reject/assign now call `approveRequest`, `rejectRequest`, and `assignRequest` with `projectId`
- Updated `VerificationStatus` component with three states:
  - **Unknown project** — ID not in directory
  - **No request** — project exists, no verification submitted
  - **Lifecycle status** — PENDING / VERIFIED / REJECTED from persisted data
- Stats panel shows live counts from `verificationService.getStats()`

### Test plan
- [ ] Submit a verification request from `/verify`
- [ ] Confirm status lookup shows PENDING
- [ ] Approve/reject from `/admin` → status updates for the user
- [ ] Lookup unknown ID → "Project Not Found"
- [ ] Lookup known project with no request → "No Verification Request"

---

## #192 — Profile page

**Commit title:** `feat: build profile page with wallet activity and owned projects`

**PR description:**

### Summary
The profile page now uses wallet state, Horizon account data, and shared services to show a full account summary — not just a placeholder.

### Changes
- Added `useWalletTransactions` hook (Horizon recent transactions)
- Added `projectService.getProjectsByOwner()` for wallet-owned projects
- Profile sections:
  - **Account summary** — address, network, balances (with loading/error states)
  - **Recent wallet activity** — last 8 on-chain transactions
  - **Your Projects** — projects where `ownerAddress` matches connected wallet
  - **Your Reviews**, **Saved Projects**, **Verification Requests** (existing, retained)
- Activity stats sidebar expanded with saved, owned, transactions, and verification counts

### Test plan
- [ ] Disconnected state shows connect-wallet panel
- [ ] Connected wallet shows address and balances
- [ ] Recent transactions load (or show clean empty/error state)
- [ ] Owned projects list renders for wallets with `ownerAddress` matches
- [ ] Loading spinners show while account/tx data fetches

---

## #229 — Moderation queue

**Commit title:** `feat: add project submission moderation queue for admins`

**PR description:**

### Summary
New project submissions are recorded in a moderation queue with automatic suspicious-flagging. Flagged, rejected, and pending submissions are excluded from Discover; admins can review and update moderation state.

### Changes
- New types: `ProjectSubmission`, `ProjectSubmissionModerationStatus`
- New `projectSubmissionService` (localStorage persistence)
- New `lib/submission-quality.ts` — quality scoring + suspicious flag detection (low score, duplicate name, short description, shortened URLs, missing audit)
- `ProjectForm` records submissions after successful on-chain register
- Discover page filters via `projectService.getDiscoverableProjects()` (legacy projects without records remain visible)
- Admin **Submissions** tab with approve / reject / flag actions and flag-reason display

### Auto-moderation rules
| Condition | Initial status |
|-----------|----------------|
| 2+ flag reasons | `flagged` |
| 1 flag reason | `pending` |
| Clean submission | `approved` |

### Test plan
- [ ] Submit a project with low quality score → appears in admin queue as flagged/pending
- [ ] Flagged/rejected projects hidden from `/discover`
- [ ] Admin approves submission → project appears in Discover
- [ ] Admin rejects with reason → reason stored, project hidden
- [ ] Legacy mock projects still visible (no moderation record)

---

## #234 — Rating distribution

**Commit title:** `feat: add rating distribution summary on project detail pages`

**PR description:**

### Summary
Extracted a reusable rating distribution component showing per-star counts and percentages. Distribution updates reactively when reviews change; empty state is handled cleanly.

### Changes
- New `RatingDistributionSummary` component with `computeRatingDistribution()` helper
- Replaced inline distribution UI in `app/projects/[id]/page.tsx`
- Shows count **and** percentage per star (e.g. `2 (67%)`)
- Empty state message when zero reviews
- Added unit tests in `__tests__/components/RatingDistributionSummary.test.tsx`

### Test plan
- [ ] Project with reviews shows average + 5-bar histogram
- [ ] Add/delete a review → bars update
- [ ] Project with zero reviews shows empty-state message
- [ ] Run `RatingDistributionSummary` tests

---

### New files
- `dongle/services/project/project-submission.service.ts`
- `dongle/components/reviews/RatingDistributionSummary.tsx`
- `dongle/hooks/useWalletTransactions.ts`
- `dongle/lib/submission-quality.ts`
- `dongle/lib/project-id.ts`
- `dongle/__tests__/components/RatingDistributionSummary.test.tsx`
- `dongle/__tests__/services/project-submission.service.test.ts`

closes #191 
closes #192 
closes #229 
closes #234