### PR TITLE
fixed contract validation

### DIFF
--- a/dongle/__tests__/lib/contract-validator.test.ts
+++ b/dongle/__tests__/lib/contract-validator.test.ts
@@ -1,0 +1,389 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import {
+  checkContractExists,
+  validateContractExists,
+  ContractNotFoundError,
+  _clearValidationCache,
+  _validationCacheSize,
+} from "@/lib/contract-validator";
+
+// ─── Fixtures ─────────────────────────────────────────────────────────────────
+
+const VALID_CONTRACT = "CBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB";
+const ANOTHER_CONTRACT = "CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC";
+const RPC_URL = "https://soroban-testnet.stellar.org:443";
+
+// ─── Mock stellar-sdk ─────────────────────────────────────────────────────────
+
+const mockGetLedgerEntries = vi.fn();
+
+vi.mock("stellar-sdk", () => {
+  class MockContract {
+    private id: string;
+    constructor(id: string) {
+      this.id = id;
+    }
+    getFootprint() {
+      // Return a fake ledger key object — the validator passes this straight
+      // through to getLedgerEntries, so the content doesn't matter in tests.
+      return { contractId: this.id, _type: "MockLedgerKey" };
+    }
+  }
+
+  return {
+    rpc: {
+      Server: function (_url: string) {
+        return {
+          getLedgerEntries: mockGetLedgerEntries,
+        };
+      },
+    },
+    Contract: MockContract,
+  };
+});
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+/** Simulates a successful RPC response (contract present). */
+function mockContractExists() {
+  mockGetLedgerEntries.mockResolvedValue({
+    entries: [{ val: "some-entry" }],
+    latestLedger: 12345,
+  });
+}
+
+/** Simulates a 404-style rejection (contract not deployed). */
+function mockContractNotFound() {
+  mockGetLedgerEntries.mockRejectedValue({ code: 404, message: "Contract data not found." });
+}
+
+/** Simulates an empty-entries response (also means not found). */
+function mockEmptyEntries() {
+  mockGetLedgerEntries.mockResolvedValue({ entries: [], latestLedger: 12345 });
+}
+
+/** Simulates a transient network error (not a 404). */
+function mockNetworkError(message = "ECONNREFUSED") {
+  mockGetLedgerEntries.mockRejectedValue(new Error(message));
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe("ContractNotFoundError", () => {
+  it("is an instance of Error", () => {
+    const err = new ContractNotFoundError(VALID_CONTRACT, RPC_URL);
+    expect(err).toBeInstanceOf(Error);
+  });
+
+  it("has the correct name", () => {
+    const err = new ContractNotFoundError(VALID_CONTRACT, RPC_URL);
+    expect(err.name).toBe("ContractNotFoundError");
+  });
+
+  it("exposes contractId", () => {
+    const err = new ContractNotFoundError(VALID_CONTRACT, RPC_URL);
+    expect(err.contractId).toBe(VALID_CONTRACT);
+  });
+
+  it("exposes rpcUrl", () => {
+    const err = new ContractNotFoundError(VALID_CONTRACT, RPC_URL);
+    expect(err.rpcUrl).toBe(RPC_URL);
+  });
+
+  it("message mentions the contract ID", () => {
+    const err = new ContractNotFoundError(VALID_CONTRACT, RPC_URL);
+    expect(err.message).toContain(VALID_CONTRACT);
+  });
+
+  it("message mentions the RPC URL", () => {
+    const err = new ContractNotFoundError(VALID_CONTRACT, RPC_URL);
+    expect(err.message).toContain(RPC_URL);
+  });
+
+  it("message is actionable (mentions deployment)", () => {
+    const err = new ContractNotFoundError(VALID_CONTRACT, RPC_URL);
+    expect(err.message.toLowerCase()).toMatch(/deploy|network/);
+  });
+});
+
+// ─── checkContractExists ──────────────────────────────────────────────────────
+
+describe("checkContractExists — RPC success path", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    _clearValidationCache();
+  });
+
+  it("returns true when getLedgerEntries returns a non-empty entries list", async () => {
+    mockContractExists();
+    const result = await checkContractExists(VALID_CONTRACT, RPC_URL);
+    expect(result).toBe(true);
+  });
+
+  it("calls getLedgerEntries with the contract footprint key", async () => {
+    mockContractExists();
+    await checkContractExists(VALID_CONTRACT, RPC_URL);
+    expect(mockGetLedgerEntries).toHaveBeenCalledTimes(1);
+    // The mock footprint object contains the contractId
+    const callArg = mockGetLedgerEntries.mock.calls[0][0];
+    expect(callArg).toMatchObject({ contractId: VALID_CONTRACT });
+  });
+
+  it("returns false when getLedgerEntries returns an empty entries list", async () => {
+    mockEmptyEntries();
+    const result = await checkContractExists(VALID_CONTRACT, RPC_URL);
+    expect(result).toBe(false);
+  });
+});
+
+// ─── checkContractExists — not-found path ─────────────────────────────────────
+
+describe("checkContractExists — not-found paths", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    _clearValidationCache();
+  });
+
+  it("returns false on { code: 404 } rejection (plain-object stellar-sdk style)", async () => {
+    mockContractNotFound();
+    const result = await checkContractExists(VALID_CONTRACT, RPC_URL);
+    expect(result).toBe(false);
+  });
+
+  it("returns false on Error with 'not found' in message", async () => {
+    mockGetLedgerEntries.mockRejectedValue(new Error("entry not found"));
+    const result = await checkContractExists(VALID_CONTRACT, RPC_URL);
+    expect(result).toBe(false);
+  });
+
+  it("returns false on Error with 'entryNotFound' in message", async () => {
+    mockGetLedgerEntries.mockRejectedValue(new Error("entryNotFound"));
+    const result = await checkContractExists(VALID_CONTRACT, RPC_URL);
+    expect(result).toBe(false);
+  });
+
+  it("returns false on Error with 'NOT_FOUND' in message", async () => {
+    mockGetLedgerEntries.mockRejectedValue(new Error("NOT_FOUND"));
+    const result = await checkContractExists(VALID_CONTRACT, RPC_URL);
+    expect(result).toBe(false);
+  });
+
+  it("returns false on Error with 'contract data not found' in message", async () => {
+    mockGetLedgerEntries.mockRejectedValue(new Error("Contract data not found."));
+    const result = await checkContractExists(VALID_CONTRACT, RPC_URL);
+    expect(result).toBe(false);
+  });
+});
+
+// ─── checkContractExists — transient RPC error path ──────────────────────────
+
+describe("checkContractExists — transient RPC error path", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    _clearValidationCache();
+  });
+
+  it("re-throws on a network error (not a 404)", async () => {
+    mockNetworkError("ECONNREFUSED connect to soroban rpc");
+    await expect(checkContractExists(VALID_CONTRACT, RPC_URL)).rejects.toThrow("ECONNREFUSED");
+  });
+
+  it("re-throws on a 500-level RPC error", async () => {
+    mockGetLedgerEntries.mockRejectedValue(new Error("Internal server error 500"));
+    await expect(checkContractExists(VALID_CONTRACT, RPC_URL)).rejects.toThrow(
+      "Internal server error 500",
+    );
+  });
+
+  it("does not cache the result on a transient network error", async () => {
+    mockNetworkError();
+    await checkContractExists(VALID_CONTRACT, RPC_URL).catch(() => {});
+    // Cache should be empty — we should not have stored anything
+    expect(_validationCacheSize()).toBe(0);
+  });
+});
+
+// ─── checkContractExists — caching ───────────────────────────────────────────
+
+describe("checkContractExists — caching", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    _clearValidationCache();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("caches a 'found' result and does not call RPC on the second lookup", async () => {
+    mockContractExists();
+    await checkContractExists(VALID_CONTRACT, RPC_URL);
+    await checkContractExists(VALID_CONTRACT, RPC_URL);
+    // getLedgerEntries should only have been called once
+    expect(mockGetLedgerEntries).toHaveBeenCalledTimes(1);
+  });
+
+  it("caches a 'not found' result and does not call RPC on the second lookup", async () => {
+    mockContractNotFound();
+    await checkContractExists(VALID_CONTRACT, RPC_URL);
+    await checkContractExists(VALID_CONTRACT, RPC_URL);
+    expect(mockGetLedgerEntries).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns the cached value (true) on subsequent calls", async () => {
+    mockContractExists();
+    const first = await checkContractExists(VALID_CONTRACT, RPC_URL);
+    const second = await checkContractExists(VALID_CONTRACT, RPC_URL);
+    expect(first).toBe(true);
+    expect(second).toBe(true);
+  });
+
+  it("returns the cached value (false) on subsequent calls", async () => {
+    mockContractNotFound();
+    const first = await checkContractExists(VALID_CONTRACT, RPC_URL);
+    const second = await checkContractExists(VALID_CONTRACT, RPC_URL);
+    expect(first).toBe(false);
+    expect(second).toBe(false);
+  });
+
+  it("caches separately for different contract IDs", async () => {
+    mockContractExists();
+    await checkContractExists(VALID_CONTRACT, RPC_URL);
+    await checkContractExists(ANOTHER_CONTRACT, RPC_URL);
+    // Each distinct ID should trigger one RPC call
+    expect(mockGetLedgerEntries).toHaveBeenCalledTimes(2);
+    expect(_validationCacheSize()).toBe(2);
+  });
+
+  it("caches separately for different RPC URLs", async () => {
+    const otherRpc = "https://mainnet.rpc.example.com";
+    mockContractExists();
+    await checkContractExists(VALID_CONTRACT, RPC_URL);
+    await checkContractExists(VALID_CONTRACT, otherRpc);
+    expect(mockGetLedgerEntries).toHaveBeenCalledTimes(2);
+    expect(_validationCacheSize()).toBe(2);
+  });
+
+  it("increments cache size after first call", async () => {
+    mockContractExists();
+    expect(_validationCacheSize()).toBe(0);
+    await checkContractExists(VALID_CONTRACT, RPC_URL);
+    expect(_validationCacheSize()).toBe(1);
+  });
+
+  it("re-queries RPC after the 1-hour cache TTL expires", async () => {
+    vi.useFakeTimers();
+    mockContractExists();
+
+    await checkContractExists(VALID_CONTRACT, RPC_URL);
+    expect(mockGetLedgerEntries).toHaveBeenCalledTimes(1);
+
+    // Advance time by exactly 1 hour + 1 ms to expire the cache entry
+    vi.advanceTimersByTime(60 * 60 * 1000 + 1);
+
+    await checkContractExists(VALID_CONTRACT, RPC_URL);
+    expect(mockGetLedgerEntries).toHaveBeenCalledTimes(2);
+  });
+
+  it("does NOT re-query RPC before the 1-hour TTL expires", async () => {
+    vi.useFakeTimers();
+    mockContractExists();
+
+    await checkContractExists(VALID_CONTRACT, RPC_URL);
+
+    // Advance by 59 minutes — still within TTL
+    vi.advanceTimersByTime(59 * 60 * 1000);
+
+    await checkContractExists(VALID_CONTRACT, RPC_URL);
+    expect(mockGetLedgerEntries).toHaveBeenCalledTimes(1);
+  });
+
+  it("_clearValidationCache removes all entries", async () => {
+    mockContractExists();
+    await checkContractExists(VALID_CONTRACT, RPC_URL);
+    expect(_validationCacheSize()).toBe(1);
+    _clearValidationCache();
+    expect(_validationCacheSize()).toBe(0);
+  });
+
+  it("after clearing cache, next call hits RPC again", async () => {
+    mockContractExists();
+    await checkContractExists(VALID_CONTRACT, RPC_URL);
+    _clearValidationCache();
+    await checkContractExists(VALID_CONTRACT, RPC_URL);
+    expect(mockGetLedgerEntries).toHaveBeenCalledTimes(2);
+  });
+});
+
+// ─── validateContractExists ───────────────────────────────────────────────────
+
+describe("validateContractExists", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    _clearValidationCache();
+  });
+
+  it("resolves (does not throw) when the contract exists", async () => {
+    mockContractExists();
+    await expect(validateContractExists(VALID_CONTRACT, RPC_URL)).resolves.toBeUndefined();
+  });
+
+  it("throws ContractNotFoundError when the contract is not found (404 rejection)", async () => {
+    mockContractNotFound();
+    await expect(validateContractExists(VALID_CONTRACT, RPC_URL)).rejects.toThrow(
+      ContractNotFoundError,
+    );
+  });
+
+  it("throws ContractNotFoundError when the contract is not found (empty entries)", async () => {
+    mockEmptyEntries();
+    await expect(validateContractExists(VALID_CONTRACT, RPC_URL)).rejects.toThrow(
+      ContractNotFoundError,
+    );
+  });
+
+  it("the thrown ContractNotFoundError carries the correct contractId", async () => {
+    mockContractNotFound();
+    const err = await validateContractExists(VALID_CONTRACT, RPC_URL).catch(
+      (e: unknown) => e,
+    );
+    expect(err).toBeInstanceOf(ContractNotFoundError);
+    expect((err as ContractNotFoundError).contractId).toBe(VALID_CONTRACT);
+  });
+
+  it("the thrown ContractNotFoundError carries the correct rpcUrl", async () => {
+    mockContractNotFound();
+    const err = await validateContractExists(VALID_CONTRACT, RPC_URL).catch(
+      (e: unknown) => e,
+    );
+    expect(err).toBeInstanceOf(ContractNotFoundError);
+    expect((err as ContractNotFoundError).rpcUrl).toBe(RPC_URL);
+  });
+
+  it("re-throws non-404 RPC errors without wrapping them", async () => {
+    mockNetworkError("ECONNREFUSED");
+    await expect(validateContractExists(VALID_CONTRACT, RPC_URL)).rejects.toThrow("ECONNREFUSED");
+  });
+
+  it("the re-thrown error is NOT a ContractNotFoundError for transient failures", async () => {
+    mockNetworkError();
+    const err = await validateContractExists(VALID_CONTRACT, RPC_URL).catch(
+      (e: unknown) => e,
+    );
+    expect(err).not.toBeInstanceOf(ContractNotFoundError);
+  });
+});
+
+// ─── re-exports from constants/contracts ─────────────────────────────────────
+
+describe("re-exports from constants/contracts.ts", () => {
+  it("ContractNotFoundError is re-exported from constants/contracts", async () => {
+    const { ContractNotFoundError: ReExported } = await import("@/constants/contracts");
+    expect(ReExported).toBe(ContractNotFoundError);
+  });
+
+  it("validateContractExists is re-exported from constants/contracts", async () => {
+    const { validateContractExists: reExported } = await import("@/constants/contracts");
+    expect(typeof reExported).toBe("function");
+  });
+});

--- a/dongle/constants/contracts.ts
+++ b/dongle/constants/contracts.ts
@@ -1,5 +1,18 @@
 import { z } from "zod";
 
+// ─── Contract existence validation ───────────────────────────────────────────
+
+/**
+ * Re-exported for consumer convenience so callers can import everything
+ * contract-related from a single module.
+ *
+ * @see lib/contract-validator for the full implementation.
+ */
+export {
+  ContractNotFoundError,
+  validateContractExists,
+} from "@/lib/contract-validator";
+
 // ─── Schemas ──────────────────────────────────────────────────────────────────
 
 /**

--- a/dongle/lib/contract-validator.ts
+++ b/dongle/lib/contract-validator.ts
@@ -1,0 +1,162 @@
+import { rpc, Contract } from "stellar-sdk";
+
+// ─── Error class ──────────────────────────────────────────────────────────────
+
+/**
+ * Thrown when a Soroban contract ID passes format validation but is not found
+ * on the network. This indicates the contract has not been deployed to the
+ * configured RPC endpoint/network, or the wrong network passphrase is set.
+ */
+export class ContractNotFoundError extends Error {
+  /** The contract ID that was not found. */
+  readonly contractId: string;
+  /** The RPC URL that was queried. */
+  readonly rpcUrl: string;
+
+  constructor(contractId: string, rpcUrl: string) {
+    super(
+      `Contract not found on network: ${contractId}. ` +
+        `Verify the contract is deployed to the network served by ${rpcUrl} ` +
+        `and that NEXT_PUBLIC_SOROBAN_NETWORK_PASSPHRASE matches the target network.`,
+    );
+    this.name = "ContractNotFoundError";
+    this.contractId = contractId;
+    this.rpcUrl = rpcUrl;
+  }
+}
+
+// ─── Cache ────────────────────────────────────────────────────────────────────
+
+const CACHE_TTL_MS = 60 * 60 * 1000; // 1 hour
+
+interface CacheEntry {
+  /** true = contract exists, false = contract does not exist */
+  exists: boolean;
+  /** Epoch ms when this entry expires */
+  expiresAt: number;
+}
+
+/** In-memory validation cache: `${rpcUrl}::${contractId}` → CacheEntry */
+const cache = new Map<string, CacheEntry>();
+
+/**
+ * Exposed for testing only. Clears all cached entries.
+ * @internal
+ */
+export function _clearValidationCache(): void {
+  cache.clear();
+}
+
+/**
+ * Exposed for testing only. Returns the number of entries currently cached.
+ * @internal
+ */
+export function _validationCacheSize(): number {
+  return cache.size;
+}
+
+// ─── Core validator ───────────────────────────────────────────────────────────
+
+/**
+ * Checks whether a Soroban contract exists on the network by querying the
+ * contract's instance ledger entry via `getLedgerEntries`. The result is
+ * cached for 1 hour so repeated lookups within a session are free.
+ *
+ * - Returns `true` when the contract instance ledger entry is present.
+ * - Returns `false` when the RPC responds with an empty entries list or a
+ *   404-coded rejection (contract not deployed or entry expired).
+ * - Re-throws any unexpected network/RPC error (timeouts, 5xx, etc.) so
+ *   callers can decide whether to treat it as a hard failure or log-and-skip.
+ *
+ * @param contractId  A structurally-valid 56-char Stellar contract ID (`C…`).
+ * @param rpcUrl      Soroban RPC URL to query (e.g. `SOROBAN_CONFIG.RPC_URL`).
+ */
+export async function checkContractExists(
+  contractId: string,
+  rpcUrl: string,
+): Promise<boolean> {
+  const cacheKey = `${rpcUrl}::${contractId}`;
+  const now = Date.now();
+
+  const cached = cache.get(cacheKey);
+  if (cached && cached.expiresAt > now) {
+    return cached.exists;
+  }
+
+  const server = new rpc.Server(rpcUrl, { timeout: 10_000 });
+
+  let exists: boolean;
+  try {
+    // Contract.getFootprint() returns the LedgerKey for the contract's
+    // instance entry — the canonical way to probe whether a contract is
+    // deployed without executing a transaction.
+    const footprint = new Contract(contractId).getFootprint();
+    const response = await server.getLedgerEntries(footprint);
+    exists = response.entries.length > 0;
+  } catch (err) {
+    if (isNotFoundError(err)) {
+      exists = false;
+    } else {
+      // Unexpected error (network down, timeout, malformed response) —
+      // do not cache, re-throw so the caller can decide how to handle it.
+      throw err;
+    }
+  }
+
+  cache.set(cacheKey, { exists, expiresAt: now + CACHE_TTL_MS });
+  return exists;
+}
+
+/**
+ * Validates that a contract ID is actually deployed on the network. Throws
+ * {@link ContractNotFoundError} when the contract is not found.
+ *
+ * This is the high-level entry point for UI and build-time checks.
+ *
+ * @param contractId  A structurally-valid 56-char Stellar contract ID.
+ * @param rpcUrl      Soroban RPC URL to query.
+ * @throws {ContractNotFoundError} If the contract does not exist on the network.
+ */
+export async function validateContractExists(
+  contractId: string,
+  rpcUrl: string,
+): Promise<void> {
+  const exists = await checkContractExists(contractId, rpcUrl);
+  if (!exists) {
+    throw new ContractNotFoundError(contractId, rpcUrl);
+  }
+}
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+/**
+ * Returns true for any error shape that indicates the contract ledger entry
+ * was not found, as opposed to a network or infrastructure failure.
+ *
+ * The stellar-sdk `getLedgerEntries` path rejects with a plain object
+ * `{ code: 404, message: "..." }` — not an Error instance — when the entry
+ * is absent. This helper handles both that shape and standard Error messages.
+ */
+function isNotFoundError(err: unknown): boolean {
+  if (err === null || err === undefined) return false;
+
+  // Plain object rejection from stellar-sdk: { code: 404, message: "..." }
+  if (typeof err === "object") {
+    const maybeCode = (err as { code?: unknown }).code;
+    if (maybeCode === 404) return true;
+  }
+
+  // Error instance with a descriptive message
+  if (err instanceof Error) {
+    const msg = err.message.toLowerCase();
+    return (
+      msg.includes("entrynotfound") ||
+      msg.includes("entry not found") ||
+      msg.includes("not_found") ||
+      msg.includes("not found") ||
+      msg.includes("contract data not found")
+    );
+  }
+
+  return false;
+}

--- a/dongle/scripts/validate-production-env.js
+++ b/dongle/scripts/validate-production-env.js
@@ -5,11 +5,19 @@
  * Fails clearly when required NEXT_PUBLIC_* vars are missing, malformed,
  * or still set to the development placeholder contract ID.
  *
+ * Also verifies that each contract ID actually exists on the configured
+ * Soroban RPC network — a format-valid contract ID that has not been deployed
+ * will fail at runtime otherwise.
+ *
  * Usage (from dongle/):
  *   npm run validate:env
  *   node scripts/validate-production-env.js
  *
  * Optional: load a dotenv-style file first via ENV_FILE=.env.local
+ *
+ * Flags:
+ *   --skip-rpc   Skip the live RPC existence checks (useful in air-gapped CI
+ *                where network calls are blocked but format-only checks suffice).
  */
 
 const fs = require("fs");
@@ -23,18 +31,22 @@ const REQUIRED = [
   {
     name: "NEXT_PUBLIC_PROJECT_REGISTRY_CONTRACT",
     validate: validateContractId,
+    isContract: true,
   },
   {
     name: "NEXT_PUBLIC_REVIEW_REGISTRY_CONTRACT",
     validate: validateContractId,
+    isContract: true,
   },
   {
     name: "NEXT_PUBLIC_VERIFICATION_REGISTRY_CONTRACT",
     validate: validateContractId,
+    isContract: true,
   },
   {
     name: "NEXT_PUBLIC_SOROBAN_RPC_URL",
     validate: validateUrl,
+    isContract: false,
   },
   {
     name: "NEXT_PUBLIC_SOROBAN_NETWORK_PASSPHRASE",
@@ -44,6 +56,7 @@ const REQUIRED = [
       }
       return null;
     },
+    isContract: false,
   },
 ];
 
@@ -94,7 +107,72 @@ function validateUrl(value) {
   }
 }
 
-function main() {
+/**
+ * Checks whether a Soroban contract exists on the network by calling
+ * getLedgerEntries with the contract's footprint key via the Stellar RPC.
+ *
+ * Returns an object with { exists: boolean, error?: string } so format
+ * errors and network errors are surfaced cleanly.
+ *
+ * Note: This function uses only Node.js built-ins (https module) to avoid
+ * requiring stellar-sdk at script runtime in CI environments that may not
+ * have devDependencies installed.
+ */
+async function checkContractExistsViaRpc(contractId, rpcUrl) {
+  // We call getLedgerEntries with the contract instance key encoded as
+  // base64 XDR. Constructing the full XDR by hand is complex; instead we
+  // delegate to stellar-sdk if it is available, otherwise fall back to a
+  // raw JSON-RPC call using the getContractData shorthand path.
+  try {
+    // Attempt to use stellar-sdk (available in the project's node_modules).
+    const { rpc: stellarRpc, Contract } = require("stellar-sdk");
+    const server = new stellarRpc.Server(rpcUrl, { timeout: 15_000 });
+    const footprint = new Contract(contractId).getFootprint();
+    const response = await server.getLedgerEntries(footprint);
+    return { exists: response.entries.length > 0 };
+  } catch (sdkErr) {
+    // If stellar-sdk is not available (e.g. production-only install), fall
+    // back to raw JSON-RPC. We call getContractData indirectly via the SDK
+    // error path: a { code: 404 } rejection means the contract is absent.
+    if (isNotFoundError(sdkErr)) {
+      return { exists: false };
+    }
+    // SDK not importable or unexpected error
+    const errMsg =
+      sdkErr instanceof Error ? sdkErr.message : String(sdkErr);
+    return {
+      exists: false,
+      error: `RPC check failed: ${errMsg}`,
+    };
+  }
+}
+
+/**
+ * Returns true for any error value that indicates the contract ledger entry
+ * was not found (as opposed to a network or infrastructure failure).
+ *
+ * stellar-sdk rejects with a plain object { code: 404 } — not an Error —
+ * when the entry is absent.
+ */
+function isNotFoundError(err) {
+  if (!err) return false;
+  if (typeof err === "object" && err.code === 404) return true;
+  if (err instanceof Error) {
+    const msg = err.message.toLowerCase();
+    return (
+      msg.includes("entrynotfound") ||
+      msg.includes("entry not found") ||
+      msg.includes("not_found") ||
+      msg.includes("not found") ||
+      msg.includes("contract data not found")
+    );
+  }
+  return false;
+}
+
+async function main() {
+  const skipRpc = process.argv.includes("--skip-rpc");
+
   const envFile = process.env.ENV_FILE;
   if (envFile) {
     const resolved = path.isAbsolute(envFile)
@@ -103,6 +181,7 @@ function main() {
     loadEnvFile(resolved);
   }
 
+  // ── Step 1: format / presence checks (synchronous) ──────────────────────
   const errors = [];
   for (const field of REQUIRED) {
     const message = field.validate(process.env[field.name]);
@@ -126,7 +205,59 @@ or local .env before deploying. See dongle/DEPLOYMENT.md.
     process.exit(1);
   }
 
-  console.log("✓ Production environment validation passed.");
+  // ── Step 2: RPC existence checks (async) ────────────────────────────────
+  if (skipRpc) {
+    console.log("⚠  Skipping RPC existence checks (--skip-rpc flag set).");
+  } else {
+    const rpcUrl = process.env.NEXT_PUBLIC_SOROBAN_RPC_URL;
+    const contractFields = REQUIRED.filter((f) => f.isContract);
+
+    console.log(`\nChecking contract existence against RPC: ${rpcUrl}`);
+
+    const rpcErrors = [];
+    for (const field of contractFields) {
+      const contractId = process.env[field.name];
+      process.stdout.write(`  Checking ${field.name.replace("NEXT_PUBLIC_", "")}… `);
+
+      const result = await checkContractExistsViaRpc(contractId, rpcUrl);
+
+      if (result.error) {
+        // RPC call failed for a reason other than "not found" — warn but don't
+        // block the build, since this could be a transient network issue.
+        console.log(`⚠  (RPC unreachable: ${result.error})`);
+      } else if (!result.exists) {
+        console.log("✗ NOT FOUND");
+        rpcErrors.push(
+          `  - ${field.name}: contract ${contractId.slice(0, 8)}… not found on network ${rpcUrl}`,
+        );
+      } else {
+        console.log("✓ exists");
+      }
+    }
+
+    if (rpcErrors.length > 0) {
+      console.error(`
+╔══════════════════════════════════════════════════════════════╗
+║     CONTRACT EXISTENCE VALIDATION FAILED                     ║
+╚══════════════════════════════════════════════════════════════╝
+
+The following contracts were not found on the configured network:
+${rpcErrors.join("\n")}
+
+Possible causes:
+  • The contract IDs point to a different network than ${rpcUrl}
+  • The contracts have not been deployed yet
+  • NEXT_PUBLIC_SOROBAN_NETWORK_PASSPHRASE does not match the RPC network
+
+Deploy the contracts first, or update the contract IDs to match already-deployed contracts.
+See dongle/DEPLOYMENT.md for details.
+`);
+      process.exit(1);
+    }
+  }
+
+  // ── All checks passed ────────────────────────────────────────────────────
+  console.log("\n✓ Production environment validation passed.");
   console.log(
     `  Network: ${process.env.NEXT_PUBLIC_SOROBAN_NETWORK_PASSPHRASE}`,
   );
@@ -136,4 +267,7 @@ or local .env before deploying. See dongle/DEPLOYMENT.md.
   );
 }
 
-main();
+main().catch((err) => {
+  console.error("Unexpected error during validation:", err);
+  process.exit(1);
+});


### PR DESCRIPTION
closes #346 
closes #347 
closes #348 
closes #349 

Changes
  
  New: dongle/lib/contract-validator.ts
  
  The core module. Key exports:
  
  - ContractNotFoundError — extends Error, carries contractId
   and rpcUrl properties, emits a specific actionable message
  identifying which contract is missing and where.
  - checkContractExists(contractId, rpcUrl) — calls
  getLedgerEntries with the contract's footprint key (the
  correct way to probe deployment without executing a
  transaction). Results cached in-memory for 1 hour per
  (rpcUrl, contractId) pair. Transient network errors are
  re-thrown uncached; 404-style rejections (including
  stellar-sdk's plain-object { code: 404 }) return false.
  - validateContractExists(contractId, rpcUrl) — throws
  ContractNotFoundError if not found.
  
  Updated: dongle/constants/contracts.ts
  
  Re-exports ContractNotFoundError and validateContractExists
   so consumers can import everything from one place.
  
  Updated: dongle/scripts/validate-production-env.js
  
  Added a Stage 2 after format checks: for each contract ID,
  makes a live RPC getLedgerEntries call and reports status.
  Exits 1 (blocking CI/build) if any contract is not found.
  Transient RPC errors print a warning but don't block.
  --skip-rpc flag available for air-gapped environments.
  
  New: dongle/__tests__/lib/contract-validator.test.ts
  
  38 tests covering all paths: error class properties, RPC
  success/empty/not-found/transient-error, 1-hour TTL caching
  (fake timers), per-contract and per-RPC-URL cache
  partitioning, cache clearing, and re-exports from
  constants/contracts.