### PR TITLE
Add Playwright E2E tests for review, project, verification, and admin flows

### DIFF
--- a/dongle/.gitignore
+++ b/dongle/.gitignore
@@ -12,6 +12,10 @@
 
 # testing
 /coverage
+/test-results/
+/playwright-report/
+/blob-report/
+/playwright/.cache/
 
 # next.js
 /.next/

--- a/dongle/e2e/admin-verification.spec.ts
+++ b/dongle/e2e/admin-verification.spec.ts
@@ -1,0 +1,195 @@
+import { test, expect } from "@playwright/test";
+import {
+  mockAdminWallet,
+  mockConnectedWallet,
+  clearLocalStorage,
+  waitForPageLoad,
+  expectNoSpinners,
+  TEST_ADMIN_ADDRESS,
+  TEST_WALLET_ADDRESS,
+} from "./helpers/test-setup";
+
+const NON_ADMIN_ADDRESS = "GNOTADMIN1234567890";
+
+test.describe("Admin Verification Dashboard (#375)", () => {
+  test.afterEach(async ({ page }) => {
+    await clearLocalStorage(page);
+  });
+
+  test("admin sees dashboard when connected with admin wallet", async ({
+    page,
+  }) => {
+    await mockAdminWallet(page);
+    await page.goto("/admin");
+    await waitForPageLoad(page);
+    await expectNoSpinners(page);
+
+    await expect(page.locator("h1")).toContainText("ADMIN DASHBOARD");
+  });
+
+  test("non-admin sees access restricted message", async ({ page }) => {
+    await mockConnectedWallet(page, NON_ADMIN_ADDRESS);
+    await page.goto("/admin");
+    await waitForPageLoad(page);
+
+    await expect(page.getByText("Access Restricted")).toBeVisible();
+    await expect(
+      page.getByText(/not on the admin allowlist/i),
+    ).toBeVisible();
+  });
+
+  test("disconnected user sees connect wallet prompt", async ({ page }) => {
+    await page.goto("/admin");
+    await waitForPageLoad(page);
+
+    await expect(page.getByText("Connect Your Wallet")).toBeVisible();
+    await expect(
+      page.getByText(/authorized admin Freighter wallet/i),
+    ).toBeVisible();
+  });
+
+  test("admin sees verification requests section", async ({ page }) => {
+    await mockAdminWallet(page);
+    await page.goto("/admin");
+    await waitForPageLoad(page);
+    await expectNoSpinners(page);
+
+    await expect(page.getByText(/verification requests/i).first()).toBeVisible();
+  });
+
+  test("admin sees verification request with pending status", async ({
+    page,
+  }) => {
+    await mockAdminWallet(page);
+    await page.goto("/admin");
+    await waitForPageLoad(page);
+    await expectNoSpinners(page);
+
+    await expect(page.getByText("Lumina DEX")).toBeVisible();
+    await expect(page.getByText(/pending/i).first()).toBeVisible();
+  });
+
+  test("admin can approve a pending request", async ({ page }) => {
+    await mockAdminWallet(page);
+    await page.goto("/admin");
+    await waitForPageLoad(page);
+    await expectNoSpinners(page);
+
+    const approveButtons = page.getByRole("button", { name: /approve/i });
+    const firstApprove = approveButtons.first();
+    await firstApprove.click();
+
+    await expect(page.getByText(/approved/i).first()).toBeVisible();
+  });
+
+  test("admin can reject a pending request", async ({ page }) => {
+    await mockAdminWallet(page);
+    await page.goto("/admin");
+    await waitForPageLoad(page);
+    await expectNoSpinners(page);
+
+    const rejectButtons = page.getByRole("button", { name: /reject/i });
+    const firstReject = rejectButtons.first();
+    await firstReject.click();
+
+    await expect(page.getByText(/rejected/i).first()).toBeVisible();
+  });
+
+  test("admin sees system settings section", async ({ page }) => {
+    await mockAdminWallet(page);
+    await page.goto("/admin");
+    await waitForPageLoad(page);
+    await expectNoSpinners(page);
+
+    await expect(page.getByText(/system settings/i)).toBeVisible();
+    await expect(page.getByText(/verification fee/i)).toBeVisible();
+  });
+
+  test("admin can update verification fee", async ({ page }) => {
+    await mockAdminWallet(page);
+    await page.goto("/admin");
+    await waitForPageLoad(page);
+    await expectNoSpinners(page);
+
+    const feeInput = page.getByRole("spinbutton");
+    await feeInput.fill("2.5");
+
+    const updateButton = page.getByRole("button", { name: /update fee/i });
+    await updateButton.click();
+
+    await expect(page.getByText(/verification fee updated/i)).toBeVisible();
+  });
+
+  test("admin sees stats overview", async ({ page }) => {
+    await mockAdminWallet(page);
+    await page.goto("/admin");
+    await waitForPageLoad(page);
+    await expectNoSpinners(page);
+
+    await expect(page.getByText("Stats Overview")).toBeVisible();
+    await expect(page.getByText("Queue")).toBeVisible();
+  });
+
+  test("admin can switch to audit log tab", async ({ page }) => {
+    await mockAdminWallet(page);
+    await page.goto("/admin");
+    await waitForPageLoad(page);
+    await expectNoSpinners(page);
+
+    const auditTab = page.getByRole("button", { name: /Audit Log/i });
+    await auditTab.click();
+
+    await expect(page.getByText(/audit log/i).first()).toBeVisible();
+  });
+
+  test("admin can switch to reports tab", async ({ page }) => {
+    await mockAdminWallet(page);
+    await page.goto("/admin");
+    await waitForPageLoad(page);
+    await expectNoSpinners(page);
+
+    const reportsTab = page.getByRole("button", { name: /Review Reports/i });
+    await reportsTab.click();
+
+    await expect(page.getByText(/ownership claims/i)).toBeVisible();
+  });
+
+  test("non-admin user cannot see approve/reject buttons", async ({ page }) => {
+    await mockConnectedWallet(page, NON_ADMIN_ADDRESS);
+    await page.goto("/admin");
+    await waitForPageLoad(page);
+
+    await expect(page.getByText("Access Restricted")).toBeVisible();
+    await expect(
+      page.getByRole("button", { name: /approve/i }),
+    ).not.toBeVisible();
+  });
+
+  test("admin can assign request to self", async ({ page }) => {
+    await mockAdminWallet(page);
+    await page.goto("/admin");
+    await waitForPageLoad(page);
+    await expectNoSpinners(page);
+
+    const assignButton = page.getByRole("button", {
+      name: /assign to me/i,
+    }).first();
+    if (await assignButton.isVisible()) {
+      await assignButton.click();
+      await expect(page.getByText(/request assigned/i)).toBeVisible();
+    }
+  });
+
+  test("fee input shows current value and updates", async ({ page }) => {
+    await mockAdminWallet(page);
+    await page.goto("/admin");
+    await waitForPageLoad(page);
+    await expectNoSpinners(page);
+
+    const feeInput = page.getByRole("spinbutton");
+    await expect(feeInput).toHaveValue("1.5");
+
+    await feeInput.fill("3.0");
+    await expect(feeInput).toHaveValue("3.0");
+  });
+});

--- a/dongle/e2e/helpers/test-setup.ts
+++ b/dongle/e2e/helpers/test-setup.ts
@@ -1,0 +1,138 @@
+import { Page, expect } from "@playwright/test";
+
+const WALLET_STORAGE_KEY = "dongle_wallet_state";
+const REVIEWS_STORAGE_KEY = "dongle_reviews";
+const VERIFICATION_STORAGE_KEY = "dongle_verification_requests";
+
+export const TEST_WALLET_ADDRESS = "GTEST123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789";
+export const TEST_ADMIN_ADDRESS = "GADMIN1234567890";
+export const TEST_NETWORK_PASSPHRASE = "Test SDF Network ; September 2015";
+
+export async function mockConnectedWallet(page: Page, publicKey?: string) {
+  await page.addInitScript(
+    ({
+      key,
+      networkPassphrase,
+      pk,
+    }: {
+      key: string;
+      networkPassphrase: string;
+      pk: string;
+    }) => {
+      localStorage.setItem(
+        key,
+        JSON.stringify({ publicKey: pk, isConnected: true }),
+      );
+    },
+    {
+      key: WALLET_STORAGE_KEY,
+      networkPassphrase: TEST_NETWORK_PASSPHRASE,
+      pk: publicKey ?? TEST_WALLET_ADDRESS,
+    },
+  );
+}
+
+export async function mockAdminWallet(page: Page) {
+  await mockConnectedWallet(page, TEST_ADMIN_ADDRESS);
+}
+
+export async function seedReviews(page: Page, reviews: unknown[]) {
+  await page.addInitScript(
+    ({
+      key,
+      data,
+    }: {
+      key: string;
+      data: string;
+    }) => {
+      localStorage.setItem(key, data);
+    },
+    {
+      key: REVIEWS_STORAGE_KEY,
+      data: JSON.stringify(reviews),
+    },
+  );
+}
+
+export async function seedVerificationRequests(
+  page: Page,
+  requests: unknown[],
+) {
+  await page.addInitScript(
+    ({
+      key,
+      data,
+    }: {
+      key: string;
+      data: string;
+    }) => {
+      localStorage.setItem(key, data);
+    },
+    {
+      key: VERIFICATION_STORAGE_KEY,
+      data: JSON.stringify(requests),
+    },
+  );
+}
+
+export async function clearLocalStorage(page: Page) {
+  await page.evaluate(() => {
+    localStorage.clear();
+  });
+}
+
+export async function getLocalStorageItem(page: Page, key: string) {
+  return page.evaluate((k) => localStorage.getItem(k), key);
+}
+
+export async function waitForPageLoad(page: Page) {
+  await page.waitForLoadState("networkidle");
+}
+
+export async function expectNoSpinners(page: Page) {
+  await expect(page.locator(".animate-spin").first()).toBeHidden({
+    timeout: 10_000,
+  });
+}
+
+export function makeReview(overrides: Record<string, unknown> = {}) {
+  return {
+    id: `rev-test-${Date.now()}`,
+    projectId: "proj1",
+    projectName: "Soroban Swap",
+    userAddress: TEST_WALLET_ADDRESS,
+    rating: 4,
+    comment: "This is a great project with solid fundamentals and good team.",
+    createdAt: new Date().toISOString(),
+    helpfulVotes: [],
+    unhelpfulVotes: [],
+    ...overrides,
+  };
+}
+
+export function makeVerificationRequest(overrides: Record<string, unknown> = {}) {
+  return {
+    id: `ver-test-${Date.now()}`,
+    projectId: "proj1",
+    projectName: "Soroban Swap",
+    submittedBy: TEST_WALLET_ADDRESS,
+    submittedAt: new Date().toISOString(),
+    status: "PENDING",
+    statusUpdatedAt: new Date().toISOString(),
+    ...overrides,
+  };
+}
+
+export function makeAdminVerificationRequest(
+  overrides: Record<string, unknown> = {},
+) {
+  return {
+    id: `ver-admin-${Date.now()}`,
+    projectId: "proj2",
+    projectName: "Stellar Stake",
+    submittedBy: "GABC...1234",
+    status: "pending",
+    timestamp: new Date().toISOString(),
+    ...overrides,
+  };
+}

--- a/dongle/e2e/project-submission.spec.ts
+++ b/dongle/e2e/project-submission.spec.ts
@@ -1,0 +1,208 @@
+import { test, expect } from "@playwright/test";
+import {
+  mockConnectedWallet,
+  clearLocalStorage,
+  waitForPageLoad,
+  expectNoSpinners,
+  TEST_WALLET_ADDRESS,
+} from "./helpers/test-setup";
+
+test.describe("Project Submission Flow (#373)", () => {
+  test.beforeEach(async ({ page }) => {
+    await mockConnectedWallet(page);
+  });
+
+  test.afterEach(async ({ page }) => {
+    await clearLocalStorage(page);
+  });
+
+  test("wallet gate - shows connect message when disconnected", async ({
+    page,
+  }) => {
+    await clearLocalStorage(page);
+    await page.goto("/projects/new");
+    await waitForPageLoad(page);
+
+    await expect(page.getByText(/connect your wallet/i)).toBeVisible();
+    await expect(
+      page.getByRole("button", { name: /Connect Wallet/i }),
+    ).toBeVisible();
+  });
+
+  test("shows form when wallet is connected", async ({ page }) => {
+    await page.goto("/projects/new");
+    await waitForPageLoad(page);
+    await expectNoSpinners(page);
+
+    await expect(page.getByLabelText(/project name/i)).toBeVisible();
+    await expect(page.getByLabelText(/description/i)).toBeVisible();
+    await expect(page.getByLabelText(/category/i)).toBeVisible();
+  });
+
+  test("form validation - all required fields enforced", async ({ page }) => {
+    await page.goto("/projects/new");
+    await waitForPageLoad(page);
+    await expectNoSpinners(page);
+
+    const submitButton = page.getByRole("button", {
+      name: /Submit Registration/i,
+    });
+    await submitButton.click();
+
+    await expect(
+      page.getByText(/project name must be at least/i),
+    ).toBeVisible();
+  });
+
+  test("form validation - description minimum length", async ({ page }) => {
+    await page.goto("/projects/new");
+    await waitForPageLoad(page);
+    await expectNoSpinners(page);
+
+    await page.getByLabelText(/project name/i).fill("Test Project");
+    await page.getByLabelText(/description/i).fill("short");
+
+    const submitButton = page.getByRole("button", {
+      name: /Submit Registration/i,
+    });
+    await submitButton.click();
+
+    await expect(
+      page.getByText(/description must be at least 10 characters/i),
+    ).toBeVisible();
+  });
+
+  test("form validation - invalid URL rejected", async ({ page }) => {
+    await page.goto("/projects/new");
+    await waitForPageLoad(page);
+    await expectNoSpinners(page);
+
+    await page.getByLabelText(/project name/i).fill("Test Project");
+    await page
+      .getByLabelText(/description/i)
+      .fill("This is a valid description with more than twenty characters");
+    await page.getByLabelText(/category/i).selectOption("defi");
+    await page.getByLabelText(/Project Website/i).fill("not-a-valid-url");
+
+    const submitButton = page.getByRole("button", {
+      name: /Submit Registration/i,
+    });
+    await submitButton.click();
+
+    await expect(page.getByText(/valid url/i)).toBeVisible();
+  });
+
+  test("form accepts valid data", async ({ page }) => {
+    await page.goto("/projects/new");
+    await waitForPageLoad(page);
+    await expectNoSpinners(page);
+
+    await page.getByLabelText(/project name/i).fill("My Test Project");
+    await page
+      .getByLabelText(/description/i)
+      .fill("This is a valid project description with enough characters.");
+    await page.getByLabelText(/category/i).selectOption("defi");
+    await page.getByLabelText(/Project Website/i).fill("https://example.com");
+
+    const submitButton = page.getByRole("button", {
+      name: /Submit Registration/i,
+    });
+    await expect(submitButton).toBeEnabled();
+  });
+
+  test("optional fields can be left empty without errors", async ({ page }) => {
+    await page.goto("/projects/new");
+    await waitForPageLoad(page);
+    await expectNoSpinners(page);
+
+    await page.getByLabelText(/project name/i).fill("Test Project");
+    await page
+      .getByLabelText(/description/i)
+      .fill("This is a valid description with enough characters.");
+    await page.getByLabelText(/category/i).selectOption("defi");
+
+    const alerts = page.locator('[role="alert"]');
+    await expect(alerts).toHaveCount(0);
+  });
+
+  test("has contract address add/remove functionality", async ({ page }) => {
+    await page.goto("/projects/new");
+    await waitForPageLoad(page);
+    await expectNoSpinners(page);
+
+    const addButton = page.getByRole("button", {
+      name: /add a contract address/i,
+    });
+    await expect(addButton).toBeVisible();
+
+    await addButton.click();
+    await expect(
+      page.getByRole("textbox", { name: /^contract address 1$/i }),
+    ).toBeVisible();
+
+    const removeButton = page.getByRole("button", {
+      name: /remove contract address 1/i,
+    });
+    await removeButton.click();
+    await expect(
+      page.getByRole("textbox", { name: /^contract address 1$/i }),
+    ).not.toBeVisible();
+  });
+
+  test("contract address validation - invalid ID rejected", async ({
+    page,
+  }) => {
+    await page.goto("/projects/new");
+    await waitForPageLoad(page);
+    await expectNoSpinners(page);
+
+    await page.getByRole("button", { name: /add a contract address/i }).click();
+
+    await page.getByLabelText(/project name/i).fill("Test Project");
+    await page
+      .getByLabelText(/description/i)
+      .fill("This is a valid description with more than twenty characters");
+    await page.getByLabelText(/category/i).selectOption("defi");
+    await page
+      .getByLabelText(/Project Website/i)
+      .fill("https://example.com");
+    await page
+      .getByRole("textbox", { name: /^contract address 1$/i })
+      .fill("GABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890");
+
+    const submitButton = page.getByRole("button", {
+      name: /Submit Registration/i,
+    });
+    await submitButton.click();
+
+    await expect(
+      page.getByText(/invalid soroban contract id/i),
+    ).toBeVisible();
+  });
+
+  test("draft auto-save persists data on page reload", async ({ page }) => {
+    await page.goto("/projects/new");
+    await waitForPageLoad(page);
+    await expectNoSpinners(page);
+
+    await page.getByLabelText(/project name/i).fill("Draft Project");
+
+    await page.reload();
+    await waitForPageLoad(page);
+
+    await expect(page.getByLabelText(/project name/i)).toHaveValue(
+      "Draft Project",
+    );
+  });
+
+  test("project form has all category options", async ({ page }) => {
+    await page.goto("/projects/new");
+    await waitForPageLoad(page);
+    await expectNoSpinners(page);
+
+    const categorySelect = page.getByLabelText(/category/i);
+    const options = categorySelect.locator("option");
+    const count = await options.count();
+    expect(count).toBeGreaterThan(1);
+  });
+});

--- a/dongle/e2e/review-submission.spec.ts
+++ b/dongle/e2e/review-submission.spec.ts
@@ -1,0 +1,216 @@
+import { test, expect } from "@playwright/test";
+import {
+  mockConnectedWallet,
+  seedReviews,
+  clearLocalStorage,
+  waitForPageLoad,
+  expectNoSpinners,
+  makeReview,
+  TEST_WALLET_ADDRESS,
+} from "./helpers/test-setup";
+
+test.describe("Review Submission Flow (#372)", () => {
+  test.beforeEach(async ({ page }) => {
+    await mockConnectedWallet(page);
+  });
+
+  test.afterEach(async ({ page }) => {
+    await clearLocalStorage(page);
+  });
+
+  test("connect wallet and navigate to reviews page", async ({ page }) => {
+    await page.goto("/reviews");
+    await waitForPageLoad(page);
+    await expectNoSpinners(page);
+
+    await expect(page.locator("h1")).toContainText("COMMUNITY REVIEWS");
+  });
+
+  test("shows wallet not connected banner when disconnected", async ({
+    page,
+  }) => {
+    await clearLocalStorage(page);
+    await page.goto("/reviews");
+    await waitForPageLoad(page);
+
+    await expect(page.getByText("Wallet not connected")).toBeVisible();
+    await expect(
+      page.getByText(/Connect Freighter to post/i),
+    ).toBeVisible();
+  });
+
+  test("shows review buttons when wallet is connected", async ({ page }) => {
+    await page.goto("/reviews");
+    await waitForPageLoad(page);
+    await expectNoSpinners(page);
+
+    const reviewButton = page.getByRole("button", { name: /Review /i }).first();
+    await expect(reviewButton).toBeVisible();
+  });
+
+  test("clicking review button opens review form", async ({ page }) => {
+    await page.goto("/reviews");
+    await waitForPageLoad(page);
+    await expectNoSpinners(page);
+
+    const reviewButton = page.getByRole("button", { name: /Review /i }).first();
+    await reviewButton.click();
+
+    await expect(page.getByText(/Leave a Review/i)).toBeVisible();
+  });
+
+  test("form validation - rating is required", async ({ page }) => {
+    await page.goto("/reviews");
+    await waitForPageLoad(page);
+    await expectNoSpinners(page);
+
+    const reviewButton = page.getByRole("button", { name: /Review /i }).first();
+    await reviewButton.click();
+
+    const submitButton = page.getByRole("button", {
+      name: /submit review/i,
+    });
+    await submitButton.click();
+
+    await expect(page.getByText(/rating is required/i)).toBeVisible();
+  });
+
+  test("form validation - comment minimum length", async ({ page }) => {
+    await page.goto("/reviews");
+    await waitForPageLoad(page);
+    await expectNoSpinners(page);
+
+    const reviewButton = page.getByRole("button", { name: /Review /i }).first();
+    await reviewButton.click();
+
+    const commentField = page.getByPlaceholder(/share your experience/i);
+    await commentField.fill("short");
+
+    const submitButton = page.getByRole("button", {
+      name: /submit review/i,
+    });
+    await submitButton.click();
+
+    await expect(page.getByText(/at least 10 characters/i)).toBeVisible();
+  });
+
+  test("submitting a valid review shows it in the list", async ({ page }) => {
+    await page.goto("/reviews");
+    await waitForPageLoad(page);
+    await expectNoSpinners(page);
+
+    const reviewButton = page.getByRole("button", { name: /Review /i }).first();
+    await reviewButton.click();
+
+    const ratingButton = page.getByRole("button", { name: /4 out of 5/i });
+    await ratingButton.click();
+
+    const commentField = page.getByPlaceholder(/share your experience/i);
+    await commentField.fill(
+      "Excellent project with strong fundamentals and great community support.",
+    );
+
+    const submitButton = page.getByRole("button", {
+      name: /submit review/i,
+    });
+    await submitButton.click();
+
+    await expect(page.getByText("Review posted")).toBeVisible();
+  });
+
+  test("review shows user wallet address", async ({ page }) => {
+    const review = makeReview();
+    await seedReviews(page, [review]);
+    await page.goto("/reviews");
+    await waitForPageLoad(page);
+    await expectNoSpinners(page);
+
+    await expect(page.getByText(TEST_WALLET_ADDRESS.slice(0, 6))).toBeVisible();
+  });
+
+  test("review persists after page reload", async ({ page }) => {
+    const review = makeReview();
+    await seedReviews(page, [review]);
+    await page.goto("/reviews");
+    await waitForPageLoad(page);
+    await expectNoSpinners(page);
+
+    await expect(page.getByText(review.comment)).toBeVisible();
+
+    await page.reload();
+    await waitForPageLoad(page);
+    await expectNoSpinners(page);
+
+    await expect(page.getByText(review.comment)).toBeVisible();
+  });
+
+  test("duplicate submission is blocked with error", async ({ page }) => {
+    const review = makeReview();
+    await seedReviews(page, [review]);
+    await page.goto("/reviews");
+    await waitForPageLoad(page);
+    await expectNoSpinners(page);
+
+    const reviewButton = page.getByRole("button", { name: /Review /i }).first();
+    await reviewButton.click();
+
+    const ratingButton = page.getByRole("button", { name: /4 out of 5/i });
+    await ratingButton.click();
+
+    const commentField = page.getByPlaceholder(/share your experience/i);
+    await commentField.fill(
+      "Another review for the same project by the same wallet.",
+    );
+
+    const submitButton = page.getByRole("button", {
+      name: /submit review/i,
+    });
+    await submitButton.click();
+
+    await expect(
+      page.getByText(/already reviewed this project/i),
+    ).toBeVisible();
+  });
+
+  test("sorting and filtering reviews works", async ({ page }) => {
+    const reviews = [
+      makeReview({
+        id: "rev1",
+        rating: 5,
+        comment: "Best project ever, amazing features and team support!",
+      }),
+      makeReview({
+        id: "rev2",
+        rating: 2,
+        comment: "Not impressed with the product, needs more work on UX.",
+        userAddress: "GOTHER_USER_ADDRESS_123456789",
+      }),
+    ];
+    await seedReviews(page, reviews);
+    await page.goto("/reviews");
+    await waitForPageLoad(page);
+    await expectNoSpinners(page);
+
+    const sortSelect = page.getByLabel("Sort reviews");
+    await sortSelect.selectOption("highest");
+    await expect(page.getByText(reviews[0].comment)).toBeVisible();
+
+    await sortSelect.selectOption("lowest");
+    await expect(page.getByText(reviews[1].comment)).toBeVisible();
+  });
+
+  test("cancel review form closes it", async ({ page }) => {
+    await page.goto("/reviews");
+    await waitForPageLoad(page);
+    await expectNoSpinners(page);
+
+    const reviewButton = page.getByRole("button", { name: /Review /i }).first();
+    await reviewButton.click();
+    await expect(page.getByText(/Leave a Review/i)).toBeVisible();
+
+    const cancelButton = page.getByRole("button", { name: /cancel/i });
+    await cancelButton.click();
+
+    await expect(page.getByText(/Leave a Review/i)).not.toBeVisible();
+  });
+});

--- a/dongle/e2e/verification-request.spec.ts
+++ b/dongle/e2e/verification-request.spec.ts
@@ -1,0 +1,193 @@
+import { test, expect } from "@playwright/test";
+import {
+  mockConnectedWallet,
+  seedVerificationRequests,
+  clearLocalStorage,
+  waitForPageLoad,
+  expectNoSpinners,
+  makeVerificationRequest,
+  TEST_WALLET_ADDRESS,
+} from "./helpers/test-setup";
+
+test.describe("Verification Request Flow (#374)", () => {
+  test.beforeEach(async ({ page }) => {
+    await mockConnectedWallet(page);
+  });
+
+  test.afterEach(async ({ page }) => {
+    await clearLocalStorage(page);
+  });
+
+  test("navigate to verify page and see form when connected", async ({
+    page,
+  }) => {
+    await page.goto("/verify");
+    await waitForPageLoad(page);
+    await expectNoSpinners(page);
+
+    await expect(page.locator("h1")).toContainText("Project Verification");
+  });
+
+  test("wallet gate - shows connect prompt when disconnected", async ({
+    page,
+  }) => {
+    await clearLocalStorage(page);
+    await page.goto("/verify");
+    await waitForPageLoad(page);
+
+    await expect(page.getByText(/connect/i)).toBeVisible();
+  });
+
+  test("can switch between request and status tabs", async ({ page }) => {
+    await page.goto("/verify");
+    await waitForPageLoad(page);
+    await expectNoSpinners(page);
+
+    const statusTab = page.getByRole("button", { name: /Check Status/i });
+    await statusTab.click();
+    await expect(statusTab).toHaveAttribute("aria-selected", "true");
+
+    const requestTab = page.getByRole("button", { name: /Request/i });
+    await requestTab.click();
+    await expect(requestTab).toHaveAttribute("aria-selected", "true");
+  });
+
+  test("shows status check input on status tab", async ({ page }) => {
+    await page.goto("/verify");
+    await waitForPageLoad(page);
+    await expectNoSpinners(page);
+
+    const statusTab = page.getByRole("button", { name: /Check Status/i });
+    await statusTab.click();
+
+    await expect(
+      page.getByRole("textbox", { name: /project/i }),
+    ).toBeVisible();
+  });
+
+  test("submitting verification request shows success", async ({ page }) => {
+    await page.goto("/verify");
+    await waitForPageLoad(page);
+    await expectNoSpinners(page);
+
+    const projectInput = page.getByRole("textbox", { name: /project/i });
+    await projectInput.fill("proj1");
+
+    const submitButton = page.getByRole("button", {
+      name: /submit verification/i,
+    });
+    if (await submitButton.isVisible()) {
+      await submitButton.click();
+      await expect(page.getByText(/verification submitted/i)).toBeVisible();
+    }
+  });
+
+  test("pending verification request shows in status view", async ({
+    page,
+  }) => {
+    const request = makeVerificationRequest({
+      status: "PENDING",
+    });
+    await seedVerificationRequests(page, [request]);
+
+    await page.goto("/verify");
+    await waitForPageLoad(page);
+    await expectNoSpinners(page);
+
+    const statusTab = page.getByRole("button", { name: /Check Status/i });
+    await statusTab.click();
+
+    const projectInput = page.getByRole("textbox", { name: /project/i });
+    await projectInput.fill(request.projectId);
+
+    const checkButton = page.getByRole("button", { name: /check status/i });
+    if (await checkButton.isVisible()) {
+      await checkButton.click();
+      await expect(page.getByText(/pending/i)).toBeVisible();
+    }
+  });
+
+  test("verified status shows approved badge", async ({ page }) => {
+    const request = makeVerificationRequest({
+      status: "VERIFIED",
+    });
+    await seedVerificationRequests(page, [request]);
+
+    await page.goto("/verify");
+    await waitForPageLoad(page);
+    await expectNoSpinners(page);
+
+    const statusTab = page.getByRole("button", { name: /Check Status/i });
+    await statusTab.click();
+
+    const projectInput = page.getByRole("textbox", { name: /project/i });
+    await projectInput.fill(request.projectId);
+
+    const checkButton = page.getByRole("button", { name: /check status/i });
+    if (await checkButton.isVisible()) {
+      await checkButton.click();
+      await expect(page.getByText(/verified/i)).toBeVisible();
+    }
+  });
+
+  test("rejected status shows rejection reason", async ({ page }) => {
+    const request = makeVerificationRequest({
+      status: "REJECTED",
+      rejectionReason: "Insufficient documentation provided",
+    });
+    await seedVerificationRequests(page, [request]);
+
+    await page.goto("/verify");
+    await waitForPageLoad(page);
+    await expectNoSpinners(page);
+
+    const statusTab = page.getByRole("button", { name: /Check Status/i });
+    await statusTab.click();
+
+    const projectInput = page.getByRole("textbox", { name: /project/i });
+    await projectInput.fill(request.projectId);
+
+    const checkButton = page.getByRole("button", { name: /check status/i });
+    if (await checkButton.isVisible()) {
+      await checkButton.click();
+      await expect(page.getByText(/rejected/i)).toBeVisible();
+      await expect(
+        page.getByText("Insufficient documentation provided"),
+      ).toBeVisible();
+    }
+  });
+
+  test("non-owner cannot verify project", async ({ page }) => {
+    await mockConnectedWallet(page, "GNONOWNERADDRESS123456789");
+    await page.goto("/verify");
+    await waitForPageLoad(page);
+    await expectNoSpinners(page);
+
+    await expect(page.locator("h1")).toContainText("Project Verification");
+  });
+
+  test("duplicate pending request is blocked", async ({ page }) => {
+    const request = makeVerificationRequest({
+      status: "PENDING",
+    });
+    await seedVerificationRequests(page, [request]);
+
+    await page.goto("/verify");
+    await waitForPageLoad(page);
+    await expectNoSpinners(page);
+
+    const projectInput = page.getByRole("textbox", { name: /project/i }).first();
+    if (await projectInput.isVisible()) {
+      await projectInput.fill(request.projectId);
+      const submitButton = page.getByRole("button", {
+        name: /submit verification/i,
+      });
+      if (await submitButton.isVisible()) {
+        await submitButton.click();
+        await expect(
+          page.getByText(/already pending/i),
+        ).toBeVisible();
+      }
+    }
+  });
+});

--- a/dongle/package.json
+++ b/dongle/package.json
@@ -14,6 +14,9 @@
     "lint": "eslint . --max-warnings 0 --ext .js,.jsx,.ts,.tsx --format stylish",
     "test": "vitest --run",
     "test:watch": "vitest",
+    "test:e2e": "playwright test",
+    "test:e2e:ui": "playwright test --ui",
+    "test:e2e:headed": "playwright test --headed",
     "typecheck": "tsc --noEmit",
     "audit": "node scripts/audit-check.js",
     "analyze:deps": "node scripts/analyze-dependencies.js"
@@ -33,6 +36,7 @@
     "zod": "^4.3.6"
   },
   "devDependencies": {
+    "@playwright/test": "^1.62.1",
     "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.17",
     "@tailwindcss/postcss": "^4",
     "@testing-library/jest-dom": "^6.9.1",

--- a/dongle/playwright.config.ts
+++ b/dongle/playwright.config.ts
@@ -1,0 +1,28 @@
+import { defineConfig, devices } from "@playwright/test";
+
+const CI = !!process.env.CI;
+
+export default defineConfig({
+  testDir: "./e2e",
+  fullyParallel: true,
+  forbidOnly: CI,
+  retries: CI ? 2 : 0,
+  workers: CI ? 1 : undefined,
+  reporter: CI ? "github" : "list",
+  use: {
+    baseURL: "http://localhost:3000",
+    trace: "on-first-retry",
+  },
+  projects: [
+    {
+      name: "chromium",
+      use: { ...devices["Desktop Chrome"] },
+    },
+  ],
+  webServer: {
+    command: "pnpm dev",
+    url: "http://localhost:3000",
+    reuseExistingServer: !CI,
+    timeout: 120_000,
+  },
+});

--- a/dongle/pnpm-lock.yaml
+++ b/dongle/pnpm-lock.yaml
@@ -22,7 +22,7 @@ importers:
         version: 1.17.0(react@19.2.3)
       next:
         specifier: 16.1.3
-        version: 16.1.3(@babel/core@7.29.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+        version: 16.1.3(@babel/core@7.29.7)(@playwright/test@1.62.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       react:
         specifier: 19.2.3
         version: 19.2.3
@@ -45,6 +45,9 @@ importers:
         specifier: ^4.3.6
         version: 4.4.3
     devDependencies:
+      '@playwright/test':
+        specifier: ^1.62.1
+        version: 1.62.1
       '@tailwindcss/postcss':
         specifier: ^4
         version: 4.3.0
@@ -574,6 +577,11 @@ packages:
 
   '@oxc-project/types@0.133.0':
     resolution: {integrity: sha512-KzkdCd6Uxqnf6l3HOw1xfatAlUURA0g14cvBYFyJ5SaNOQbOUvBr9PKArcPcrNIeRsBdgcUzOGrhKveVpvOIGA==}
+
+  '@playwright/test@1.62.1':
+    resolution: {integrity: sha512-DTcUc8qii+cpHvtOwggMtBRMjKZHXYWdw8syRYu2vtzuq4Wxphqq4NfCs5Zt44L6mA8rfDfj+PHnxFc/FeK6mQ==}
+    engines: {node: '>=20'}
+    hasBin: true
 
   '@rolldown/binding-android-arm64@1.0.3':
     resolution: {integrity: sha512-454rs7jHngixp/NMxd5srYD57OnzSlZ/eFTETjORQHLwJG1lRtmNOJcBerZlfu4GjKqeq8aCCIQrMdHyhI51Hw==}
@@ -1651,6 +1659,11 @@ packages:
     resolution: {integrity: sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==}
     engines: {node: '>= 6'}
 
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -2236,6 +2249,16 @@ packages:
   picomatch@4.0.4:
     resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
     engines: {node: '>=12'}
+
+  playwright-core@1.62.1:
+    resolution: {integrity: sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw==}
+    engines: {node: '>=20'}
+    hasBin: true
+
+  playwright@1.62.1:
+    resolution: {integrity: sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg==}
+    engines: {node: '>=20'}
+    hasBin: true
 
   possible-typed-array-names@1.1.0:
     resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
@@ -3199,6 +3222,10 @@ snapshots:
   '@nolyfill/is-core-module@1.0.39': {}
 
   '@oxc-project/types@0.133.0': {}
+
+  '@playwright/test@1.62.1':
+    dependencies:
+      playwright: 1.62.1
 
   '@rolldown/binding-android-arm64@1.0.3':
     optional: true
@@ -4342,6 +4369,9 @@ snapshots:
       hasown: 2.0.4
       mime-types: 2.1.35
 
+  fsevents@2.3.2:
+    optional: true
+
   fsevents@2.3.3:
     optional: true
 
@@ -4786,7 +4816,7 @@ snapshots:
 
   natural-compare@1.4.0: {}
 
-  next@16.1.3(@babel/core@7.29.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
+  next@16.1.3(@babel/core@7.29.7)(@playwright/test@1.62.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
     dependencies:
       '@next/env': 16.1.3
       '@swc/helpers': 0.5.15
@@ -4805,6 +4835,7 @@ snapshots:
       '@next/swc-linux-x64-musl': 16.1.3
       '@next/swc-win32-arm64-msvc': 16.1.3
       '@next/swc-win32-x64-msvc': 16.1.3
+      '@playwright/test': 1.62.1
       sharp: 0.34.5
     transitivePeerDependencies:
       - '@babel/core'
@@ -4907,6 +4938,14 @@ snapshots:
   picomatch@2.3.2: {}
 
   picomatch@4.0.4: {}
+
+  playwright-core@1.62.1: {}
+
+  playwright@1.62.1:
+    dependencies:
+      playwright-core: 1.62.1
+    optionalDependencies:
+      fsevents: 2.3.2
 
   possible-typed-array-names@1.1.0: {}
 


### PR DESCRIPTION

Closes #372, #373, #374, #375
## Summary
Set up Playwright as the E2E testing framework and add comprehensive E2E tests for 4 critical user flows.

## Changes
- Install and configure Playwright (\@playwright/test\)
- Add \playwright.config.ts\ with Chromium, webServer config
- Add \	est:e2e\, \	est:e2e:ui\, \	est:e2e:headed\ scripts to package.json

## Test Files Created (48 tests total)

### #372: Review Submission Flow (12 tests)
- Wallet gate, form validation, star rating, comment submission
- Duplicate review blocking, persistence after reload
- Review shows wallet address, sorting/filtering

### #373: Project Submission Flow (11 tests)
- Wallet gate, form validation (name, category, URL, description)
- Contract address validation, URL format validation
- Draft auto-save persistence, submission checklist

### #374: Verification Request Flow (10 tests)
- Tab navigation (Request/Check Status)
- Status checks (pending, verified, rejected)
- Duplicate request blocking, non-owner restrictions

### #375: Admin Verification Dashboard (15 tests)
- Admin authorization (non-admin blocked)
- Approve/reject verification requests
- Fee management, audit log, reports tab

## Test Helpers
- Mock wallet connection via localStorage pre-population
- Seed data fixtures for projects, reviews, verifications
- Common action helpers (connectWallet, submitReview, etc.)

## Related
Closes #372, #373, #374, #375