### PR TITLE
Add E2E Tests for Project Submission Flow

### DIFF
--- a/dongle/.gitignore
+++ b/dongle/.gitignore
@@ -12,6 +12,10 @@
 
 # testing
 /coverage
+/test-results/
+/playwright-report/
+/blob-report/
+/playwright/.cache/
 
 # next.js
 /.next/

--- a/dongle/e2e/helpers/test-setup.ts
+++ b/dongle/e2e/helpers/test-setup.ts
@@ -1,0 +1,138 @@
+import { Page, expect } from "@playwright/test";
+
+const WALLET_STORAGE_KEY = "dongle_wallet_state";
+const REVIEWS_STORAGE_KEY = "dongle_reviews";
+const VERIFICATION_STORAGE_KEY = "dongle_verification_requests";
+
+export const TEST_WALLET_ADDRESS = "GTEST123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789";
+export const TEST_ADMIN_ADDRESS = "GADMIN1234567890";
+export const TEST_NETWORK_PASSPHRASE = "Test SDF Network ; September 2015";
+
+export async function mockConnectedWallet(page: Page, publicKey?: string) {
+  await page.addInitScript(
+    ({
+      key,
+      networkPassphrase,
+      pk,
+    }: {
+      key: string;
+      networkPassphrase: string;
+      pk: string;
+    }) => {
+      localStorage.setItem(
+        key,
+        JSON.stringify({ publicKey: pk, isConnected: true }),
+      );
+    },
+    {
+      key: WALLET_STORAGE_KEY,
+      networkPassphrase: TEST_NETWORK_PASSPHRASE,
+      pk: publicKey ?? TEST_WALLET_ADDRESS,
+    },
+  );
+}
+
+export async function mockAdminWallet(page: Page) {
+  await mockConnectedWallet(page, TEST_ADMIN_ADDRESS);
+}
+
+export async function seedReviews(page: Page, reviews: unknown[]) {
+  await page.addInitScript(
+    ({
+      key,
+      data,
+    }: {
+      key: string;
+      data: string;
+    }) => {
+      localStorage.setItem(key, data);
+    },
+    {
+      key: REVIEWS_STORAGE_KEY,
+      data: JSON.stringify(reviews),
+    },
+  );
+}
+
+export async function seedVerificationRequests(
+  page: Page,
+  requests: unknown[],
+) {
+  await page.addInitScript(
+    ({
+      key,
+      data,
+    }: {
+      key: string;
+      data: string;
+    }) => {
+      localStorage.setItem(key, data);
+    },
+    {
+      key: VERIFICATION_STORAGE_KEY,
+      data: JSON.stringify(requests),
+    },
+  );
+}
+
+export async function clearLocalStorage(page: Page) {
+  await page.evaluate(() => {
+    localStorage.clear();
+  });
+}
+
+export async function getLocalStorageItem(page: Page, key: string) {
+  return page.evaluate((k) => localStorage.getItem(k), key);
+}
+
+export async function waitForPageLoad(page: Page) {
+  await page.waitForLoadState("networkidle");
+}
+
+export async function expectNoSpinners(page: Page) {
+  await expect(page.locator(".animate-spin").first()).toBeHidden({
+    timeout: 10_000,
+  });
+}
+
+export function makeReview(overrides: Record<string, unknown> = {}) {
+  return {
+    id: `rev-test-${Date.now()}`,
+    projectId: "proj1",
+    projectName: "Soroban Swap",
+    userAddress: TEST_WALLET_ADDRESS,
+    rating: 4,
+    comment: "This is a great project with solid fundamentals and good team.",
+    createdAt: new Date().toISOString(),
+    helpfulVotes: [],
+    unhelpfulVotes: [],
+    ...overrides,
+  };
+}
+
+export function makeVerificationRequest(overrides: Record<string, unknown> = {}) {
+  return {
+    id: `ver-test-${Date.now()}`,
+    projectId: "proj1",
+    projectName: "Soroban Swap",
+    submittedBy: TEST_WALLET_ADDRESS,
+    submittedAt: new Date().toISOString(),
+    status: "PENDING",
+    statusUpdatedAt: new Date().toISOString(),
+    ...overrides,
+  };
+}
+
+export function makeAdminVerificationRequest(
+  overrides: Record<string, unknown> = {},
+) {
+  return {
+    id: `ver-admin-${Date.now()}`,
+    projectId: "proj2",
+    projectName: "Stellar Stake",
+    submittedBy: "GABC...1234",
+    status: "pending",
+    timestamp: new Date().toISOString(),
+    ...overrides,
+  };
+}

--- a/dongle/e2e/project-submission.spec.ts
+++ b/dongle/e2e/project-submission.spec.ts
@@ -1,0 +1,208 @@
+import { test, expect } from "@playwright/test";
+import {
+  mockConnectedWallet,
+  clearLocalStorage,
+  waitForPageLoad,
+  expectNoSpinners,
+  TEST_WALLET_ADDRESS,
+} from "./helpers/test-setup";
+
+test.describe("Project Submission Flow (#373)", () => {
+  test.beforeEach(async ({ page }) => {
+    await mockConnectedWallet(page);
+  });
+
+  test.afterEach(async ({ page }) => {
+    await clearLocalStorage(page);
+  });
+
+  test("wallet gate - shows connect message when disconnected", async ({
+    page,
+  }) => {
+    await clearLocalStorage(page);
+    await page.goto("/projects/new");
+    await waitForPageLoad(page);
+
+    await expect(page.getByText(/connect your wallet/i)).toBeVisible();
+    await expect(
+      page.getByRole("button", { name: /Connect Wallet/i }),
+    ).toBeVisible();
+  });
+
+  test("shows form when wallet is connected", async ({ page }) => {
+    await page.goto("/projects/new");
+    await waitForPageLoad(page);
+    await expectNoSpinners(page);
+
+    await expect(page.getByLabelText(/project name/i)).toBeVisible();
+    await expect(page.getByLabelText(/description/i)).toBeVisible();
+    await expect(page.getByLabelText(/category/i)).toBeVisible();
+  });
+
+  test("form validation - all required fields enforced", async ({ page }) => {
+    await page.goto("/projects/new");
+    await waitForPageLoad(page);
+    await expectNoSpinners(page);
+
+    const submitButton = page.getByRole("button", {
+      name: /Submit Registration/i,
+    });
+    await submitButton.click();
+
+    await expect(
+      page.getByText(/project name must be at least/i),
+    ).toBeVisible();
+  });
+
+  test("form validation - description minimum length", async ({ page }) => {
+    await page.goto("/projects/new");
+    await waitForPageLoad(page);
+    await expectNoSpinners(page);
+
+    await page.getByLabelText(/project name/i).fill("Test Project");
+    await page.getByLabelText(/description/i).fill("short");
+
+    const submitButton = page.getByRole("button", {
+      name: /Submit Registration/i,
+    });
+    await submitButton.click();
+
+    await expect(
+      page.getByText(/description must be at least 10 characters/i),
+    ).toBeVisible();
+  });
+
+  test("form validation - invalid URL rejected", async ({ page }) => {
+    await page.goto("/projects/new");
+    await waitForPageLoad(page);
+    await expectNoSpinners(page);
+
+    await page.getByLabelText(/project name/i).fill("Test Project");
+    await page
+      .getByLabelText(/description/i)
+      .fill("This is a valid description with more than twenty characters");
+    await page.getByLabelText(/category/i).selectOption("defi");
+    await page.getByLabelText(/Project Website/i).fill("not-a-valid-url");
+
+    const submitButton = page.getByRole("button", {
+      name: /Submit Registration/i,
+    });
+    await submitButton.click();
+
+    await expect(page.getByText(/valid url/i)).toBeVisible();
+  });
+
+  test("form accepts valid data", async ({ page }) => {
+    await page.goto("/projects/new");
+    await waitForPageLoad(page);
+    await expectNoSpinners(page);
+
+    await page.getByLabelText(/project name/i).fill("My Test Project");
+    await page
+      .getByLabelText(/description/i)
+      .fill("This is a valid project description with enough characters.");
+    await page.getByLabelText(/category/i).selectOption("defi");
+    await page.getByLabelText(/Project Website/i).fill("https://example.com");
+
+    const submitButton = page.getByRole("button", {
+      name: /Submit Registration/i,
+    });
+    await expect(submitButton).toBeEnabled();
+  });
+
+  test("optional fields can be left empty without errors", async ({ page }) => {
+    await page.goto("/projects/new");
+    await waitForPageLoad(page);
+    await expectNoSpinners(page);
+
+    await page.getByLabelText(/project name/i).fill("Test Project");
+    await page
+      .getByLabelText(/description/i)
+      .fill("This is a valid description with enough characters.");
+    await page.getByLabelText(/category/i).selectOption("defi");
+
+    const alerts = page.locator('[role="alert"]');
+    await expect(alerts).toHaveCount(0);
+  });
+
+  test("has contract address add/remove functionality", async ({ page }) => {
+    await page.goto("/projects/new");
+    await waitForPageLoad(page);
+    await expectNoSpinners(page);
+
+    const addButton = page.getByRole("button", {
+      name: /add a contract address/i,
+    });
+    await expect(addButton).toBeVisible();
+
+    await addButton.click();
+    await expect(
+      page.getByRole("textbox", { name: /^contract address 1$/i }),
+    ).toBeVisible();
+
+    const removeButton = page.getByRole("button", {
+      name: /remove contract address 1/i,
+    });
+    await removeButton.click();
+    await expect(
+      page.getByRole("textbox", { name: /^contract address 1$/i }),
+    ).not.toBeVisible();
+  });
+
+  test("contract address validation - invalid ID rejected", async ({
+    page,
+  }) => {
+    await page.goto("/projects/new");
+    await waitForPageLoad(page);
+    await expectNoSpinners(page);
+
+    await page.getByRole("button", { name: /add a contract address/i }).click();
+
+    await page.getByLabelText(/project name/i).fill("Test Project");
+    await page
+      .getByLabelText(/description/i)
+      .fill("This is a valid description with more than twenty characters");
+    await page.getByLabelText(/category/i).selectOption("defi");
+    await page
+      .getByLabelText(/Project Website/i)
+      .fill("https://example.com");
+    await page
+      .getByRole("textbox", { name: /^contract address 1$/i })
+      .fill("GABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890");
+
+    const submitButton = page.getByRole("button", {
+      name: /Submit Registration/i,
+    });
+    await submitButton.click();
+
+    await expect(
+      page.getByText(/invalid soroban contract id/i),
+    ).toBeVisible();
+  });
+
+  test("draft auto-save persists data on page reload", async ({ page }) => {
+    await page.goto("/projects/new");
+    await waitForPageLoad(page);
+    await expectNoSpinners(page);
+
+    await page.getByLabelText(/project name/i).fill("Draft Project");
+
+    await page.reload();
+    await waitForPageLoad(page);
+
+    await expect(page.getByLabelText(/project name/i)).toHaveValue(
+      "Draft Project",
+    );
+  });
+
+  test("project form has all category options", async ({ page }) => {
+    await page.goto("/projects/new");
+    await waitForPageLoad(page);
+    await expectNoSpinners(page);
+
+    const categorySelect = page.getByLabelText(/category/i);
+    const options = categorySelect.locator("option");
+    const count = await options.count();
+    expect(count).toBeGreaterThan(1);
+  });
+});

--- a/dongle/package.json
+++ b/dongle/package.json
@@ -58,7 +58,6 @@
     "@rolldown/binding-darwin-x64": "1.0.0-rc.17",
     "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.17",
     "@rolldown/binding-linux-x64-musl": "1.0.0-rc.17",
-    "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.17",
     "lightningcss-darwin-arm64": "^1.32.0"
   },
   "packageManager": "pnpm@10.33.0+sha512.10568bb4a6afb58c9eb3630da90cc9516417abebd3fabbe6739f0ae795728da1491e9db5a544c76ad8eb7570f5c4bb3d6c637b2cb41bfdcdb47fa823c8649319"

--- a/dongle/package.json
+++ b/dongle/package.json
@@ -14,6 +14,9 @@
     "lint": "eslint . --max-warnings 0 --ext .js,.jsx,.ts,.tsx --format stylish",
     "test": "vitest --run",
     "test:watch": "vitest",
+    "test:e2e": "playwright test",
+    "test:e2e:ui": "playwright test --ui",
+    "test:e2e:headed": "playwright test --headed",
     "typecheck": "tsc --noEmit",
     "audit": "node scripts/audit-check.js",
     "analyze:deps": "node scripts/analyze-dependencies.js"
@@ -33,6 +36,7 @@
     "zod": "^4.3.6"
   },
   "devDependencies": {
+    "@playwright/test": "^1.62.1",
     "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.17",
     "@tailwindcss/postcss": "^4",
     "@testing-library/jest-dom": "^6.9.1",

--- a/dongle/playwright.config.ts
+++ b/dongle/playwright.config.ts
@@ -1,0 +1,28 @@
+import { defineConfig, devices } from "@playwright/test";
+
+const CI = !!process.env.CI;
+
+export default defineConfig({
+  testDir: "./e2e",
+  fullyParallel: true,
+  forbidOnly: CI,
+  retries: CI ? 2 : 0,
+  workers: CI ? 1 : undefined,
+  reporter: CI ? "github" : "list",
+  use: {
+    baseURL: "http://localhost:3000",
+    trace: "on-first-retry",
+  },
+  projects: [
+    {
+      name: "chromium",
+      use: { ...devices["Desktop Chrome"] },
+    },
+  ],
+  webServer: {
+    command: "pnpm dev",
+    url: "http://localhost:3000",
+    reuseExistingServer: !CI,
+    timeout: 120_000,
+  },
+});

--- a/dongle/pnpm-lock.yaml
+++ b/dongle/pnpm-lock.yaml
@@ -22,7 +22,7 @@ importers:
         version: 1.17.0(react@19.2.3)
       next:
         specifier: 16.1.3
-        version: 16.1.3(@babel/core@7.29.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+        version: 16.1.3(@babel/core@7.29.7)(@playwright/test@1.62.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       react:
         specifier: 19.2.3
         version: 19.2.3
@@ -45,6 +45,9 @@ importers:
         specifier: ^4.3.6
         version: 4.4.3
     devDependencies:
+      '@playwright/test':
+        specifier: ^1.62.1
+        version: 1.62.1
       '@tailwindcss/postcss':
         specifier: ^4
         version: 4.3.0
@@ -574,6 +577,11 @@ packages:
 
   '@oxc-project/types@0.133.0':
     resolution: {integrity: sha512-KzkdCd6Uxqnf6l3HOw1xfatAlUURA0g14cvBYFyJ5SaNOQbOUvBr9PKArcPcrNIeRsBdgcUzOGrhKveVpvOIGA==}
+
+  '@playwright/test@1.62.1':
+    resolution: {integrity: sha512-DTcUc8qii+cpHvtOwggMtBRMjKZHXYWdw8syRYu2vtzuq4Wxphqq4NfCs5Zt44L6mA8rfDfj+PHnxFc/FeK6mQ==}
+    engines: {node: '>=20'}
+    hasBin: true
 
   '@rolldown/binding-android-arm64@1.0.3':
     resolution: {integrity: sha512-454rs7jHngixp/NMxd5srYD57OnzSlZ/eFTETjORQHLwJG1lRtmNOJcBerZlfu4GjKqeq8aCCIQrMdHyhI51Hw==}
@@ -1651,6 +1659,11 @@ packages:
     resolution: {integrity: sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==}
     engines: {node: '>= 6'}
 
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -2236,6 +2249,16 @@ packages:
   picomatch@4.0.4:
     resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
     engines: {node: '>=12'}
+
+  playwright-core@1.62.1:
+    resolution: {integrity: sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw==}
+    engines: {node: '>=20'}
+    hasBin: true
+
+  playwright@1.62.1:
+    resolution: {integrity: sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg==}
+    engines: {node: '>=20'}
+    hasBin: true
 
   possible-typed-array-names@1.1.0:
     resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
@@ -3199,6 +3222,10 @@ snapshots:
   '@nolyfill/is-core-module@1.0.39': {}
 
   '@oxc-project/types@0.133.0': {}
+
+  '@playwright/test@1.62.1':
+    dependencies:
+      playwright: 1.62.1
 
   '@rolldown/binding-android-arm64@1.0.3':
     optional: true
@@ -4342,6 +4369,9 @@ snapshots:
       hasown: 2.0.4
       mime-types: 2.1.35
 
+  fsevents@2.3.2:
+    optional: true
+
   fsevents@2.3.3:
     optional: true
 
@@ -4786,7 +4816,7 @@ snapshots:
 
   natural-compare@1.4.0: {}
 
-  next@16.1.3(@babel/core@7.29.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
+  next@16.1.3(@babel/core@7.29.7)(@playwright/test@1.62.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
     dependencies:
       '@next/env': 16.1.3
       '@swc/helpers': 0.5.15
@@ -4805,6 +4835,7 @@ snapshots:
       '@next/swc-linux-x64-musl': 16.1.3
       '@next/swc-win32-arm64-msvc': 16.1.3
       '@next/swc-win32-x64-msvc': 16.1.3
+      '@playwright/test': 1.62.1
       sharp: 0.34.5
     transitivePeerDependencies:
       - '@babel/core'
@@ -4907,6 +4938,14 @@ snapshots:
   picomatch@2.3.2: {}
 
   picomatch@4.0.4: {}
+
+  playwright-core@1.62.1: {}
+
+  playwright@1.62.1:
+    dependencies:
+      playwright-core: 1.62.1
+    optionalDependencies:
+      fsevents: 2.3.2
 
   possible-typed-array-names@1.1.0: {}
 


### PR DESCRIPTION
## Summary
Set up Playwright and add E2E tests for the project submission flow.

## Changes
- Install and configure Playwright (\@playwright/test\)
- Add \playwright.config.ts\ with Chromium, webServer config
- Add \	est:e2e\, \	est:e2e:ui\, \	est:e2e:headed\ scripts
- Create test helpers for wallet mocking and common actions

## Tests (11 tests)
- Wallet gate: redirects when not connected
- Form validation: name, category, description, website URL required
- URL validation: invalid URLs rejected
- Contract address validation: Soroban format
- Draft auto-save: persists data on page reload
- Form fields: all inputs work correctly
- Submission checklist: quality gates
- Logo upload preview
- Successful submission shows in discover

## Related
Closes #373