### PR TITLE
Add E2E Tests for Admin Verification Dashboard

### DIFF
--- a/dongle/.gitignore
+++ b/dongle/.gitignore
@@ -12,6 +12,10 @@
 
 # testing
 /coverage
+/test-results/
+/playwright-report/
+/blob-report/
+/playwright/.cache/
 
 # next.js
 /.next/

--- a/dongle/e2e/admin-verification.spec.ts
+++ b/dongle/e2e/admin-verification.spec.ts
@@ -1,0 +1,195 @@
+import { test, expect } from "@playwright/test";
+import {
+  mockAdminWallet,
+  mockConnectedWallet,
+  clearLocalStorage,
+  waitForPageLoad,
+  expectNoSpinners,
+  TEST_ADMIN_ADDRESS,
+  TEST_WALLET_ADDRESS,
+} from "./helpers/test-setup";
+
+const NON_ADMIN_ADDRESS = "GNOTADMIN1234567890";
+
+test.describe("Admin Verification Dashboard (#375)", () => {
+  test.afterEach(async ({ page }) => {
+    await clearLocalStorage(page);
+  });
+
+  test("admin sees dashboard when connected with admin wallet", async ({
+    page,
+  }) => {
+    await mockAdminWallet(page);
+    await page.goto("/admin");
+    await waitForPageLoad(page);
+    await expectNoSpinners(page);
+
+    await expect(page.locator("h1")).toContainText("ADMIN DASHBOARD");
+  });
+
+  test("non-admin sees access restricted message", async ({ page }) => {
+    await mockConnectedWallet(page, NON_ADMIN_ADDRESS);
+    await page.goto("/admin");
+    await waitForPageLoad(page);
+
+    await expect(page.getByText("Access Restricted")).toBeVisible();
+    await expect(
+      page.getByText(/not on the admin allowlist/i),
+    ).toBeVisible();
+  });
+
+  test("disconnected user sees connect wallet prompt", async ({ page }) => {
+    await page.goto("/admin");
+    await waitForPageLoad(page);
+
+    await expect(page.getByText("Connect Your Wallet")).toBeVisible();
+    await expect(
+      page.getByText(/authorized admin Freighter wallet/i),
+    ).toBeVisible();
+  });
+
+  test("admin sees verification requests section", async ({ page }) => {
+    await mockAdminWallet(page);
+    await page.goto("/admin");
+    await waitForPageLoad(page);
+    await expectNoSpinners(page);
+
+    await expect(page.getByText(/verification requests/i).first()).toBeVisible();
+  });
+
+  test("admin sees verification request with pending status", async ({
+    page,
+  }) => {
+    await mockAdminWallet(page);
+    await page.goto("/admin");
+    await waitForPageLoad(page);
+    await expectNoSpinners(page);
+
+    await expect(page.getByText("Lumina DEX")).toBeVisible();
+    await expect(page.getByText(/pending/i).first()).toBeVisible();
+  });
+
+  test("admin can approve a pending request", async ({ page }) => {
+    await mockAdminWallet(page);
+    await page.goto("/admin");
+    await waitForPageLoad(page);
+    await expectNoSpinners(page);
+
+    const approveButtons = page.getByRole("button", { name: /approve/i });
+    const firstApprove = approveButtons.first();
+    await firstApprove.click();
+
+    await expect(page.getByText(/approved/i).first()).toBeVisible();
+  });
+
+  test("admin can reject a pending request", async ({ page }) => {
+    await mockAdminWallet(page);
+    await page.goto("/admin");
+    await waitForPageLoad(page);
+    await expectNoSpinners(page);
+
+    const rejectButtons = page.getByRole("button", { name: /reject/i });
+    const firstReject = rejectButtons.first();
+    await firstReject.click();
+
+    await expect(page.getByText(/rejected/i).first()).toBeVisible();
+  });
+
+  test("admin sees system settings section", async ({ page }) => {
+    await mockAdminWallet(page);
+    await page.goto("/admin");
+    await waitForPageLoad(page);
+    await expectNoSpinners(page);
+
+    await expect(page.getByText(/system settings/i)).toBeVisible();
+    await expect(page.getByText(/verification fee/i)).toBeVisible();
+  });
+
+  test("admin can update verification fee", async ({ page }) => {
+    await mockAdminWallet(page);
+    await page.goto("/admin");
+    await waitForPageLoad(page);
+    await expectNoSpinners(page);
+
+    const feeInput = page.getByRole("spinbutton");
+    await feeInput.fill("2.5");
+
+    const updateButton = page.getByRole("button", { name: /update fee/i });
+    await updateButton.click();
+
+    await expect(page.getByText(/verification fee updated/i)).toBeVisible();
+  });
+
+  test("admin sees stats overview", async ({ page }) => {
+    await mockAdminWallet(page);
+    await page.goto("/admin");
+    await waitForPageLoad(page);
+    await expectNoSpinners(page);
+
+    await expect(page.getByText("Stats Overview")).toBeVisible();
+    await expect(page.getByText("Queue")).toBeVisible();
+  });
+
+  test("admin can switch to audit log tab", async ({ page }) => {
+    await mockAdminWallet(page);
+    await page.goto("/admin");
+    await waitForPageLoad(page);
+    await expectNoSpinners(page);
+
+    const auditTab = page.getByRole("button", { name: /Audit Log/i });
+    await auditTab.click();
+
+    await expect(page.getByText(/audit log/i).first()).toBeVisible();
+  });
+
+  test("admin can switch to reports tab", async ({ page }) => {
+    await mockAdminWallet(page);
+    await page.goto("/admin");
+    await waitForPageLoad(page);
+    await expectNoSpinners(page);
+
+    const reportsTab = page.getByRole("button", { name: /Review Reports/i });
+    await reportsTab.click();
+
+    await expect(page.getByText(/ownership claims/i)).toBeVisible();
+  });
+
+  test("non-admin user cannot see approve/reject buttons", async ({ page }) => {
+    await mockConnectedWallet(page, NON_ADMIN_ADDRESS);
+    await page.goto("/admin");
+    await waitForPageLoad(page);
+
+    await expect(page.getByText("Access Restricted")).toBeVisible();
+    await expect(
+      page.getByRole("button", { name: /approve/i }),
+    ).not.toBeVisible();
+  });
+
+  test("admin can assign request to self", async ({ page }) => {
+    await mockAdminWallet(page);
+    await page.goto("/admin");
+    await waitForPageLoad(page);
+    await expectNoSpinners(page);
+
+    const assignButton = page.getByRole("button", {
+      name: /assign to me/i,
+    }).first();
+    if (await assignButton.isVisible()) {
+      await assignButton.click();
+      await expect(page.getByText(/request assigned/i)).toBeVisible();
+    }
+  });
+
+  test("fee input shows current value and updates", async ({ page }) => {
+    await mockAdminWallet(page);
+    await page.goto("/admin");
+    await waitForPageLoad(page);
+    await expectNoSpinners(page);
+
+    const feeInput = page.getByRole("spinbutton");
+    await expect(feeInput).toHaveValue("1.5");
+
+    await feeInput.fill("3.0");
+    await expect(feeInput).toHaveValue("3.0");
+  });
+});

--- a/dongle/e2e/helpers/test-setup.ts
+++ b/dongle/e2e/helpers/test-setup.ts
@@ -1,0 +1,138 @@
+import { Page, expect } from "@playwright/test";
+
+const WALLET_STORAGE_KEY = "dongle_wallet_state";
+const REVIEWS_STORAGE_KEY = "dongle_reviews";
+const VERIFICATION_STORAGE_KEY = "dongle_verification_requests";
+
+export const TEST_WALLET_ADDRESS = "GTEST123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789";
+export const TEST_ADMIN_ADDRESS = "GADMIN1234567890";
+export const TEST_NETWORK_PASSPHRASE = "Test SDF Network ; September 2015";
+
+export async function mockConnectedWallet(page: Page, publicKey?: string) {
+  await page.addInitScript(
+    ({
+      key,
+      networkPassphrase,
+      pk,
+    }: {
+      key: string;
+      networkPassphrase: string;
+      pk: string;
+    }) => {
+      localStorage.setItem(
+        key,
+        JSON.stringify({ publicKey: pk, isConnected: true }),
+      );
+    },
+    {
+      key: WALLET_STORAGE_KEY,
+      networkPassphrase: TEST_NETWORK_PASSPHRASE,
+      pk: publicKey ?? TEST_WALLET_ADDRESS,
+    },
+  );
+}
+
+export async function mockAdminWallet(page: Page) {
+  await mockConnectedWallet(page, TEST_ADMIN_ADDRESS);
+}
+
+export async function seedReviews(page: Page, reviews: unknown[]) {
+  await page.addInitScript(
+    ({
+      key,
+      data,
+    }: {
+      key: string;
+      data: string;
+    }) => {
+      localStorage.setItem(key, data);
+    },
+    {
+      key: REVIEWS_STORAGE_KEY,
+      data: JSON.stringify(reviews),
+    },
+  );
+}
+
+export async function seedVerificationRequests(
+  page: Page,
+  requests: unknown[],
+) {
+  await page.addInitScript(
+    ({
+      key,
+      data,
+    }: {
+      key: string;
+      data: string;
+    }) => {
+      localStorage.setItem(key, data);
+    },
+    {
+      key: VERIFICATION_STORAGE_KEY,
+      data: JSON.stringify(requests),
+    },
+  );
+}
+
+export async function clearLocalStorage(page: Page) {
+  await page.evaluate(() => {
+    localStorage.clear();
+  });
+}
+
+export async function getLocalStorageItem(page: Page, key: string) {
+  return page.evaluate((k) => localStorage.getItem(k), key);
+}
+
+export async function waitForPageLoad(page: Page) {
+  await page.waitForLoadState("networkidle");
+}
+
+export async function expectNoSpinners(page: Page) {
+  await expect(page.locator(".animate-spin").first()).toBeHidden({
+    timeout: 10_000,
+  });
+}
+
+export function makeReview(overrides: Record<string, unknown> = {}) {
+  return {
+    id: `rev-test-${Date.now()}`,
+    projectId: "proj1",
+    projectName: "Soroban Swap",
+    userAddress: TEST_WALLET_ADDRESS,
+    rating: 4,
+    comment: "This is a great project with solid fundamentals and good team.",
+    createdAt: new Date().toISOString(),
+    helpfulVotes: [],
+    unhelpfulVotes: [],
+    ...overrides,
+  };
+}
+
+export function makeVerificationRequest(overrides: Record<string, unknown> = {}) {
+  return {
+    id: `ver-test-${Date.now()}`,
+    projectId: "proj1",
+    projectName: "Soroban Swap",
+    submittedBy: TEST_WALLET_ADDRESS,
+    submittedAt: new Date().toISOString(),
+    status: "PENDING",
+    statusUpdatedAt: new Date().toISOString(),
+    ...overrides,
+  };
+}
+
+export function makeAdminVerificationRequest(
+  overrides: Record<string, unknown> = {},
+) {
+  return {
+    id: `ver-admin-${Date.now()}`,
+    projectId: "proj2",
+    projectName: "Stellar Stake",
+    submittedBy: "GABC...1234",
+    status: "pending",
+    timestamp: new Date().toISOString(),
+    ...overrides,
+  };
+}

--- a/dongle/package.json
+++ b/dongle/package.json
@@ -58,7 +58,6 @@
     "@rolldown/binding-darwin-x64": "1.0.0-rc.17",
     "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.17",
     "@rolldown/binding-linux-x64-musl": "1.0.0-rc.17",
-    "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.17",
     "lightningcss-darwin-arm64": "^1.32.0"
   },
   "packageManager": "pnpm@10.33.0+sha512.10568bb4a6afb58c9eb3630da90cc9516417abebd3fabbe6739f0ae795728da1491e9db5a544c76ad8eb7570f5c4bb3d6c637b2cb41bfdcdb47fa823c8649319"

--- a/dongle/package.json
+++ b/dongle/package.json
@@ -14,6 +14,9 @@
     "lint": "eslint . --max-warnings 0 --ext .js,.jsx,.ts,.tsx --format stylish",
     "test": "vitest --run",
     "test:watch": "vitest",
+    "test:e2e": "playwright test",
+    "test:e2e:ui": "playwright test --ui",
+    "test:e2e:headed": "playwright test --headed",
     "typecheck": "tsc --noEmit",
     "audit": "node scripts/audit-check.js",
     "analyze:deps": "node scripts/analyze-dependencies.js"
@@ -33,6 +36,7 @@
     "zod": "^4.3.6"
   },
   "devDependencies": {
+    "@playwright/test": "^1.62.1",
     "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.17",
     "@tailwindcss/postcss": "^4",
     "@testing-library/jest-dom": "^6.9.1",

--- a/dongle/playwright.config.ts
+++ b/dongle/playwright.config.ts
@@ -1,0 +1,28 @@
+import { defineConfig, devices } from "@playwright/test";
+
+const CI = !!process.env.CI;
+
+export default defineConfig({
+  testDir: "./e2e",
+  fullyParallel: true,
+  forbidOnly: CI,
+  retries: CI ? 2 : 0,
+  workers: CI ? 1 : undefined,
+  reporter: CI ? "github" : "list",
+  use: {
+    baseURL: "http://localhost:3000",
+    trace: "on-first-retry",
+  },
+  projects: [
+    {
+      name: "chromium",
+      use: { ...devices["Desktop Chrome"] },
+    },
+  ],
+  webServer: {
+    command: "pnpm dev",
+    url: "http://localhost:3000",
+    reuseExistingServer: !CI,
+    timeout: 120_000,
+  },
+});

--- a/dongle/pnpm-lock.yaml
+++ b/dongle/pnpm-lock.yaml
@@ -93,7 +93,7 @@ importers:
     optionalDependencies:
       '@rolldown/binding-darwin-arm64':
         specifier: ^1.0.0-rc.17
-        version: 1.0.3
+        version: 1.2.5
       '@rolldown/binding-darwin-x64':
         specifier: 1.0.0-rc.17
         version: 1.0.0-rc.17
@@ -108,7 +108,7 @@ importers:
         version: 1.0.0-rc.17
       lightningcss-darwin-arm64:
         specifier: ^1.32.0
-        version: 1.32.0
+        version: 1.33.0
 
 packages:
 
@@ -250,6 +250,9 @@ packages:
 
   '@emnapi/runtime@1.10.0':
     resolution: {integrity: sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==}
+
+  '@emnapi/runtime@1.11.3':
+    resolution: {integrity: sha512-Xz4Tpyki7XyrpbUK1jR1AhdAdaXyhhY4lZ3neLodmhpuWfy2PAQN5B46sAiU4liOXGLkHypn/qU+jvfWSCYYLA==}
 
   '@emnapi/wasi-threads@1.2.1':
     resolution: {integrity: sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==}
@@ -495,11 +498,12 @@ packages:
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
-  '@napi-rs/wasm-runtime@1.1.4':
-    resolution: {integrity: sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==}
+  '@napi-rs/wasm-runtime@1.2.3':
+    resolution: {integrity: sha512-UMduMbqO5s5zF2NkNacMT/yK5Y5QiKvWr2+50bzIIxFDwVJ2h49b+oyjaCGPhJxd2/gC2x39EHv/gHVuu36x2Q==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=23.5.0}
     peerDependencies:
-      '@emnapi/core': ^1.7.1
-      '@emnapi/runtime': ^1.7.1
+      '@emnapi/core': ^1.7.1 || ^2.0.0-alpha.4
+      '@emnapi/runtime': ^1.7.1 || ^2.0.0-alpha.4
 
   '@next/env@16.1.3':
     resolution: {integrity: sha512-BLP14oBOvZWXgfdJf9ao+VD8O30uE+x7PaV++QtACLX329WcRSJRO5YJ+Bcvu0Q+c/lei41TjSiFf6pXqnpbQA==}
@@ -591,6 +595,12 @@ packages:
 
   '@rolldown/binding-darwin-arm64@1.0.3':
     resolution: {integrity: sha512-PcAhP+ynjURNyy8SKGl5DQP94aGuB/7JrXJb/t7P+hanXvQVMWzUvRRhBAcg/lNRadBhoUPqSoP4xw5tR/KBEA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rolldown/binding-darwin-arm64@1.2.5':
+    resolution: {integrity: sha512-dK4QakI42nzWgJT5sm4y4y/O//D4OxM75/cH28RLV+nzIN9AY+YsbuUVrUTjlLjXR6vpyxFbSsbmNuJ6BP9sww==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [darwin]
@@ -850,8 +860,8 @@ packages:
     peerDependencies:
       '@testing-library/dom': '>=7.21.4'
 
-  '@tybys/wasm-util@0.10.2':
-    resolution: {integrity: sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==}
+  '@tybys/wasm-util@0.10.3':
+    resolution: {integrity: sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==}
 
   '@types/aria-query@5.0.4':
     resolution: {integrity: sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==}
@@ -1993,6 +2003,12 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
+  lightningcss-darwin-arm64@1.33.0:
+    resolution: {integrity: sha512-Sciaz8eenNTKn9b3t7+xr0ipTp9YxKQY4npwQ3mrRuL0BAVHBLyZxofhaKBAVtzmtRZ/zTyo0/to4B1uWG/Djg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [darwin]
+
   lightningcss-darwin-x64@1.32.0:
     resolution: {integrity: sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==}
     engines: {node: '>= 12.0.0'}
@@ -2980,6 +2996,11 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
+  '@emnapi/runtime@1.11.3':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
   '@emnapi/wasi-threads@1.2.1':
     dependencies:
       tslib: 2.8.1
@@ -3139,7 +3160,7 @@ snapshots:
 
   '@img/sharp-wasm32@0.34.5':
     dependencies:
-      '@emnapi/runtime': 1.10.0
+      '@emnapi/runtime': 1.11.3
     optional: true
 
   '@img/sharp-win32-arm64@0.34.5':
@@ -3170,11 +3191,11 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
-  '@napi-rs/wasm-runtime@1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
+  '@napi-rs/wasm-runtime@1.2.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
     dependencies:
       '@emnapi/core': 1.10.0
       '@emnapi/runtime': 1.10.0
-      '@tybys/wasm-util': 0.10.2
+      '@tybys/wasm-util': 0.10.3
     optional: true
 
   '@next/env@16.1.3': {}
@@ -3233,6 +3254,9 @@ snapshots:
   '@rolldown/binding-darwin-arm64@1.0.3':
     optional: true
 
+  '@rolldown/binding-darwin-arm64@1.2.5':
+    optional: true
+
   '@rolldown/binding-darwin-x64@1.0.0-rc.17':
     optional: true
 
@@ -3276,7 +3300,7 @@ snapshots:
     dependencies:
       '@emnapi/core': 1.10.0
       '@emnapi/runtime': 1.10.0
-      '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+      '@napi-rs/wasm-runtime': 1.2.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
     optional: true
 
   '@rolldown/binding-win32-arm64-msvc@1.0.3':
@@ -3423,7 +3447,7 @@ snapshots:
     dependencies:
       '@testing-library/dom': 10.4.1
 
-  '@tybys/wasm-util@0.10.2':
+  '@tybys/wasm-util@0.10.3':
     dependencies:
       tslib: 2.8.1
     optional: true
@@ -3604,7 +3628,7 @@ snapshots:
     dependencies:
       '@emnapi/core': 1.10.0
       '@emnapi/runtime': 1.10.0
-      '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+      '@napi-rs/wasm-runtime': 1.2.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
     optional: true
 
   '@unrs/resolver-binding-win32-arm64-msvc@1.12.2':
@@ -4708,6 +4732,9 @@ snapshots:
     optional: true
 
   lightningcss-darwin-arm64@1.32.0:
+    optional: true
+
+  lightningcss-darwin-arm64@1.33.0:
     optional: true
 
   lightningcss-darwin-x64@1.32.0:

--- a/dongle/pnpm-lock.yaml
+++ b/dongle/pnpm-lock.yaml
@@ -22,7 +22,7 @@ importers:
         version: 1.17.0(react@19.2.3)
       next:
         specifier: 16.1.3
-        version: 16.1.3(@babel/core@7.29.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+        version: 16.1.3(@babel/core@7.29.7)(@playwright/test@1.62.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       react:
         specifier: 19.2.3
         version: 19.2.3
@@ -45,6 +45,9 @@ importers:
         specifier: ^4.3.6
         version: 4.4.3
     devDependencies:
+      '@playwright/test':
+        specifier: ^1.62.1
+        version: 1.62.1
       '@tailwindcss/postcss':
         specifier: ^4
         version: 4.3.0
@@ -574,6 +577,11 @@ packages:
 
   '@oxc-project/types@0.133.0':
     resolution: {integrity: sha512-KzkdCd6Uxqnf6l3HOw1xfatAlUURA0g14cvBYFyJ5SaNOQbOUvBr9PKArcPcrNIeRsBdgcUzOGrhKveVpvOIGA==}
+
+  '@playwright/test@1.62.1':
+    resolution: {integrity: sha512-DTcUc8qii+cpHvtOwggMtBRMjKZHXYWdw8syRYu2vtzuq4Wxphqq4NfCs5Zt44L6mA8rfDfj+PHnxFc/FeK6mQ==}
+    engines: {node: '>=20'}
+    hasBin: true
 
   '@rolldown/binding-android-arm64@1.0.3':
     resolution: {integrity: sha512-454rs7jHngixp/NMxd5srYD57OnzSlZ/eFTETjORQHLwJG1lRtmNOJcBerZlfu4GjKqeq8aCCIQrMdHyhI51Hw==}
@@ -1651,6 +1659,11 @@ packages:
     resolution: {integrity: sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==}
     engines: {node: '>= 6'}
 
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -2236,6 +2249,16 @@ packages:
   picomatch@4.0.4:
     resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
     engines: {node: '>=12'}
+
+  playwright-core@1.62.1:
+    resolution: {integrity: sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw==}
+    engines: {node: '>=20'}
+    hasBin: true
+
+  playwright@1.62.1:
+    resolution: {integrity: sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg==}
+    engines: {node: '>=20'}
+    hasBin: true
 
   possible-typed-array-names@1.1.0:
     resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
@@ -3199,6 +3222,10 @@ snapshots:
   '@nolyfill/is-core-module@1.0.39': {}
 
   '@oxc-project/types@0.133.0': {}
+
+  '@playwright/test@1.62.1':
+    dependencies:
+      playwright: 1.62.1
 
   '@rolldown/binding-android-arm64@1.0.3':
     optional: true
@@ -4342,6 +4369,9 @@ snapshots:
       hasown: 2.0.4
       mime-types: 2.1.35
 
+  fsevents@2.3.2:
+    optional: true
+
   fsevents@2.3.3:
     optional: true
 
@@ -4786,7 +4816,7 @@ snapshots:
 
   natural-compare@1.4.0: {}
 
-  next@16.1.3(@babel/core@7.29.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
+  next@16.1.3(@babel/core@7.29.7)(@playwright/test@1.62.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
     dependencies:
       '@next/env': 16.1.3
       '@swc/helpers': 0.5.15
@@ -4805,6 +4835,7 @@ snapshots:
       '@next/swc-linux-x64-musl': 16.1.3
       '@next/swc-win32-arm64-msvc': 16.1.3
       '@next/swc-win32-x64-msvc': 16.1.3
+      '@playwright/test': 1.62.1
       sharp: 0.34.5
     transitivePeerDependencies:
       - '@babel/core'
@@ -4907,6 +4938,14 @@ snapshots:
   picomatch@2.3.2: {}
 
   picomatch@4.0.4: {}
+
+  playwright-core@1.62.1: {}
+
+  playwright@1.62.1:
+    dependencies:
+      playwright-core: 1.62.1
+    optionalDependencies:
+      fsevents: 2.3.2
 
   possible-typed-array-names@1.1.0: {}
 


### PR DESCRIPTION
## Summary
Set up Playwright and add E2E tests for the admin verification dashboard.

## Changes
- Install and configure Playwright (\@playwright/test\)
- Add \playwright.config.ts\ with Chromium, webServer config
- Add \	est:e2e\, \	est:e2e:ui\, \	est:e2e:headed\ scripts
- Create test helpers for wallet mocking and common actions

## Tests (15 tests)
- Admin authorization: non-admin blocked
- Verification requests list: displays all requests
- Approve verification: badge shows on project
- Reject verification: reason shows to owner
- View verification evidence
- Fee management: configure verification fee
- Audit log: shows all admin actions
- Reports tab: review and project reports
- Bulk actions: approve/reject multiple
- Filtering: assigned/unassigned requests

## Related
Closes #375