### PR TITLE
fix: Remove unused imports and dead code

### DIFF
--- a/dongle/components/ui/ErrorDisplay.tsx
+++ b/dongle/components/ui/ErrorDisplay.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useRef } from "react";
-import { AlertCircle, AlertTriangle, Info, XCircle } from "lucide-react";
+import { AlertTriangle, Info, XCircle } from "lucide-react";
 import { MappedError } from "@/lib/error-mapper";
 import { useModalFocusTrap } from "@/hooks/useModalFocusTrap";
 


### PR DESCRIPTION
Closes HubDApp/Dongle-frontend#361