### PR TITLE
feat: soroban service interface, error classes, backup tools, audit compliance

### DIFF
--- a/dongle/lib/errors.ts
+++ b/dongle/lib/errors.ts
@@ -1,0 +1,164 @@
+/**
+ * Custom error classes for the Dongle frontend (#424).
+ *
+ * Every service method that can fail in a domain-specific way should throw
+ * one of these instead of a plain `Error`.  The error-mapper util knows how
+ * to turn each class into a user-friendly message.
+ */
+
+// ── Base ──────────────────────────────────────────────────────────────────────
+
+/** Base class for all domain errors. Carries an optional `code` for machine
+ *  parsing and an `actionable` hint shown to the user. */
+export class DomainError extends Error {
+  readonly code: string;
+  readonly actionable?: string;
+
+  constructor(message: string, code: string, actionable?: string) {
+    super(message);
+    this.name = this.constructor.name;
+    this.code = code;
+    this.actionable = actionable;
+  }
+}
+
+// ── Wallet ────────────────────────────────────────────────────────────────────
+
+export class WalletError extends DomainError {
+  constructor(message: string, code = "WALLET_ERROR", actionable?: string) {
+    super(message, code, actionable);
+  }
+}
+
+export class WalletNotConnectedError extends WalletError {
+  constructor() {
+    super(
+      "No wallet connected. Please connect your Freighter wallet and try again.",
+      "WALLET_NOT_CONNECTED",
+      "Click the Connect Wallet button and approve the Freighter prompt.",
+    );
+  }
+}
+
+export class WalletLockedError extends WalletError {
+  constructor() {
+    super(
+      "Your wallet is locked.",
+      "WALLET_LOCKED",
+      "Please unlock Freighter and try again.",
+    );
+  }
+}
+
+export class WalletNotInstalledError extends WalletError {
+  constructor() {
+    super(
+      "Freighter wallet extension is not installed.",
+      "WALLET_NOT_INSTALLED",
+      "Please install Freighter from the Chrome Web Store or Firefox Add-ons.",
+    );
+  }
+}
+
+// ── Network ───────────────────────────────────────────────────────────────────
+
+export class NetworkError extends DomainError {
+  constructor(message: string, code = "NETWORK_ERROR", actionable?: string) {
+    super(message, code, actionable);
+  }
+}
+
+export class NetworkTimeoutError extends NetworkError {
+  constructor() {
+    super(
+      "The request timed out. The network may be slow or unavailable.",
+      "NETWORK_TIMEOUT",
+      "Please check your internet connection and try again.",
+    );
+  }
+}
+
+export class NetworkMismatchError extends NetworkError {
+  readonly expectedNetwork: string;
+  readonly actualNetwork: string | null;
+
+  constructor(actual: string | null, expected: string, expectedLabel: string) {
+    const actualLabel = actual?.slice(0, 8) ?? "unknown";
+    super(
+      `Wrong network: wallet is on ${actualLabel}, but this app requires ${expectedLabel}.`,
+      "NETWORK_MISMATCH",
+      `Please switch your Freighter wallet to ${expectedLabel} and try again.`,
+    );
+    this.expectedNetwork = expected;
+    this.actualNetwork = actual;
+  }
+}
+
+// ── Soroban / Smart Contract ──────────────────────────────────────────────────
+
+export class SorobanError extends DomainError {
+  constructor(message: string, code = "SOROBAN_ERROR", actionable?: string) {
+    super(message, code, actionable);
+  }
+}
+
+export class TransactionFailedError extends SorobanError {
+  readonly txHash?: string;
+
+  constructor(message: string, txHash?: string) {
+    super(
+      message,
+      "TX_FAILED",
+      "Please check the transaction details and try again.",
+    );
+    this.txHash = txHash;
+  }
+}
+
+export class ContractCallError extends SorobanError {
+  constructor(message: string) {
+    super(
+      message,
+      "CONTRACT_CALL_FAILED",
+      "There was an issue with the smart contract. Please try again.",
+    );
+  }
+}
+
+// ── Account ───────────────────────────────────────────────────────────────────
+
+export class AccountError extends DomainError {
+  constructor(message: string, code = "ACCOUNT_ERROR", actionable?: string) {
+    super(message, code, actionable);
+  }
+}
+
+export class InsufficientBalanceError extends AccountError {
+  constructor() {
+    super(
+      "Insufficient balance to complete this transaction.",
+      "INSUFFICIENT_BALANCE",
+      "Please add more XLM to your account.",
+    );
+  }
+}
+
+// ── Storage ───────────────────────────────────────────────────────────────────
+
+export class StorageError extends DomainError {
+  constructor(message: string, code = "STORAGE_ERROR", actionable?: string) {
+    super(message, code, actionable);
+  }
+}
+
+// ── Data Integrity ────────────────────────────────────────────────────────────
+
+export class DataIntegrityError extends DomainError {
+  constructor(message: string) {
+    super(
+      message,
+      "DATA_INTEGRITY_ERROR",
+      "The imported data appears to be corrupted or invalid.",
+    );
+  }
+}

--- a/dongle/services/audit/audit-log.service.ts
+++ b/dongle/services/audit/audit-log.service.ts
@@ -9,6 +9,12 @@
  * - append() is the only write path; no update/delete methods are exposed.
  * - list() / getById() are read-only.
  * - Corrupt or partial records are skipped during hydration (never throw).
+ *
+ * Compliance features (#452):
+ * - exportCsv() — generates a CSV string for external audits.
+ * - redactedList() — returns entries with PII (wallet addresses) partially
+ *   redacted (first 5 + last 5 chars).
+ * - Retention: entries older than 1 year can be pruned via pruneOldEntries().
  */
 
 import {
@@ -20,6 +26,9 @@ import {
 import { generateId } from "@/lib/id-generator";
 
 export const AUDIT_LOG_STORAGE_KEY = "dongle_audit_log";
+
+/** Retention period: 1 year in milliseconds. */
+const RETENTION_MS = 365 * 24 * 60 * 60 * 1000;
 
 const VALID_ACTIONS: ReadonlySet<AuditAction> = new Set<AuditAction>([
   "admin_login",
@@ -106,6 +115,26 @@ function saveEntries(entries: AuditLogEntry[]): void {
   }
 }
 
+/**
+ * Redact a Stellar public key: show first 5 and last 5 characters only.
+ * Addresses shorter than 11 chars are returned as-is.
+ */
+function redactAddress(address: string): string {
+  if (address.length <= 10) return address;
+  return `${address.slice(0, 5)}...${address.slice(-5)}`;
+}
+
+/**
+ * Escape a value for CSV output.  Wraps in double-quotes if the value
+ * contains a comma, double-quote, or newline.
+ */
+function csvEscape(value: string): string {
+  if (value.includes(",") || value.includes('"') || value.includes("\n")) {
+    return `"${value.replace(/"/g, '""')}"`;
+  }
+  return value;
+}
+
 export const auditLogService = {
   // ── Write ────────────────────────────────────────────────────────────────
 
@@ -174,6 +203,59 @@ export const auditLogService = {
   /** Total count of stored entries (unfiltered). */
   count(): number {
     return loadEntries().length;
+  },
+
+  // ── Compliance (#452) ────────────────────────────────────────────────────
+
+  /**
+   * Return entries with wallet addresses partially redacted (first 5 + last 5 chars).
+   * Safe for display in compliance dashboards and external sharing.
+   */
+  redactedList(filter?: AuditLogFilter): AuditLogEntry[] {
+    return this.list(filter).map((entry) => ({
+      ...entry,
+      actor: redactAddress(entry.actor),
+      targetId: redactAddress(entry.targetId),
+    }));
+  },
+
+  /**
+   * Export filtered entries as a CSV string for external audit tools.
+   * Columns: id, actor, action, targetId, targetLabel, timestamp, reason.
+   */
+  exportCsv(filter?: AuditLogFilter): string {
+    const entries = this.list(filter);
+    const header = "id,actor,action,targetId,targetLabel,timestamp,reason";
+    const rows = entries.map(
+      (e) =>
+        [
+          csvEscape(e.id),
+          csvEscape(e.actor),
+          csvEscape(e.action),
+          csvEscape(e.targetId),
+          csvEscape(e.targetLabel),
+          csvEscape(e.timestamp),
+          csvEscape(e.reason ?? ""),
+        ].join(","),
+    );
+    return [header, ...rows].join("\n");
+  },
+
+  /**
+   * Remove entries older than the retention period (1 year).
+   * Returns the number of entries pruned.
+   */
+  pruneOldEntries(): number {
+    const entries = loadEntries();
+    const cutoff = Date.now() - RETENTION_MS;
+    const kept = entries.filter(
+      (e) => new Date(e.timestamp).getTime() >= cutoff,
+    );
+    const pruned = entries.length - kept.length;
+    if (pruned > 0) {
+      saveEntries(kept);
+    }
+    return pruned;
   },
 
   // ── Test helpers ─────────────────────────────────────────────────────────

--- a/dongle/services/project/backup.service.ts
+++ b/dongle/services/project/backup.service.ts
@@ -1,0 +1,194 @@
+/**
+ * Project Backup & Migration Service (#450).
+ *
+ * Exports project data as JSON, supports batch export, import with integrity
+ * validation, and QR-code generation for sharing.
+ */
+
+import type { ISorobanService } from "@/services/stellar/soroban.interface";
+import { DataIntegrityError } from "@/lib/errors";
+
+// ── Types ─────────────────────────────────────────────────────────────────────
+
+/** Serializable snapshot of a single project. */
+export interface ProjectBackup {
+  version: 1;
+  exportedAt: string;
+  project: {
+    id: string;
+    name: string;
+    category: string;
+    description: string;
+    websiteUrl: string;
+    githubUrl?: string;
+    logoUrl: string;
+    docsUrl: string;
+    auditReportUrl?: string;
+    bugBountyUrl?: string;
+    owner: string;
+    createdAt: string;
+  };
+  /** Simple SHA-256 hex of the JSON-serialised project object. */
+  checksum: string;
+}
+
+/** A batch backup containing multiple projects. */
+export interface BatchBackup {
+  version: 1;
+  exportedAt: string;
+  projects: ProjectBackup[];
+}
+
+/** Result of an import validation. */
+export interface ImportValidation {
+  valid: boolean;
+  errors: string[];
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+async function sha256Hex(data: string): Promise<string> {
+  const encoder = new TextEncoder();
+  const hashBuffer = await crypto.subtle.digest("SHA-256", encoder.encode(data));
+  return Array.from(new Uint8Array(hashBuffer))
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
+}
+
+function redactOwner(owner: string): string {
+  if (owner.length <= 10) return owner;
+  return `${owner.slice(0, 5)}...${owner.slice(-5)}`;
+}
+
+// ── Service ───────────────────────────────────────────────────────────────────
+
+export function createBackupService(sorobanService: ISorobanService) {
+  return {
+    /**
+     * Export a single project as a JSON-compatible backup.
+     */
+    async exportProject(projectId: string): Promise<ProjectBackup> {
+      const project = await sorobanService.getProject(projectId);
+      if (!project) {
+        throw new DataIntegrityError(`Project ${projectId} not found`);
+      }
+
+      const projectData = {
+        id: project.id,
+        name: project.name,
+        category: project.category,
+        description: project.description,
+        websiteUrl: project.websiteUrl,
+        githubUrl: project.githubUrl,
+        logoUrl: project.logoUrl,
+        docsUrl: project.docsUrl,
+        auditReportUrl: project.auditReportUrl,
+        bugBountyUrl: project.bugBountyUrl,
+        owner: project.owner,
+        createdAt: project.createdAt,
+      };
+
+      const checksum = await sha256Hex(JSON.stringify(projectData));
+
+      return {
+        version: 1,
+        exportedAt: new Date().toISOString(),
+        project: projectData,
+        checksum,
+      };
+    },
+
+    /**
+     * Export all projects owned by a wallet address.
+     */
+    async exportAllProjects(
+      projectIds: string[],
+    ): Promise<BatchBackup> {
+      const projects: ProjectBackup[] = [];
+      for (const id of projectIds) {
+        try {
+          const backup = await this.exportProject(id);
+          projects.push(backup);
+        } catch {
+          // Skip projects that cannot be exported
+        }
+      }
+      return {
+        version: 1,
+        exportedAt: new Date().toISOString(),
+        projects,
+      };
+    },
+
+    /**
+     * Validate an imported backup's integrity before accepting.
+     * Checks version, required fields, and checksum.
+     */
+    async validateImport(backup: unknown): Promise<ImportValidation> {
+      const errors: string[] = [];
+
+      if (!backup || typeof backup !== "object") {
+        return { valid: false, errors: ["Backup is not a valid object"] };
+      }
+
+      const b = backup as Record<string, unknown>;
+
+      if (b.version !== 1) {
+        errors.push(`Unsupported backup version: ${b.version}`);
+      }
+
+      if (!b.project || typeof b.project !== "object") {
+        errors.push("Missing or invalid project data");
+        return { valid: false, errors };
+      }
+
+      const p = b.project as Record<string, unknown>;
+      const requiredFields = ["id", "name", "category", "description", "websiteUrl", "logoUrl", "owner", "createdAt"];
+      for (const field of requiredFields) {
+        if (!p[field] || typeof p[field] !== "string") {
+          errors.push(`Missing required field: ${field}`);
+        }
+      }
+
+      if (b.checksum && typeof b.checksum === "string") {
+        const projectData = { ...p };
+        const expectedChecksum = await sha256Hex(JSON.stringify(projectData));
+        if (b.checksum !== expectedChecksum) {
+          errors.push("Checksum mismatch — data may have been tampered with");
+        }
+      }
+
+      return { valid: errors.length === 0, errors };
+    },
+
+    /**
+     * Generate a QR-code data URL for sharing a project backup.
+     * Uses a simple JSON-in-URI approach for small payloads; for larger
+     * backups the caller should host the JSON and QR the URL instead.
+     */
+    async generateShareQr(backup: ProjectBackup): Promise<string> {
+      // For small payloads, encode directly as a data URL with a simple
+      // SVG-based QR placeholder.  In production this would use a proper
+      // QR library (e.g. `qrcode` npm package).
+      const json = JSON.stringify(backup);
+      const encoded = encodeURIComponent(json);
+      return `data:application/json;charset=utf-8,${encoded}`;
+    },
+
+    /**
+     * Download a backup as a JSON file.
+     */
+    downloadBackup(backup: ProjectBackup | BatchBackup, filename: string): void {
+      const json = JSON.stringify(backup, null, 2);
+      const blob = new Blob([json], { type: "application/json" });
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement("a");
+      a.href = url;
+      a.download = filename;
+      document.body.appendChild(a);
+      a.click();
+      document.body.removeChild(a);
+      URL.revokeObjectURL(url);
+    },
+  };
+}

--- a/dongle/services/stellar/soroban.interface.ts
+++ b/dongle/services/stellar/soroban.interface.ts
@@ -1,0 +1,101 @@
+/**
+ * ISorobanService — interface for all Soroban / Project Registry operations (#422).
+ *
+ * Consumers depend on this interface rather than the concrete `sorobanService`
+ * so that a mock implementation can be injected during testing.
+ */
+
+import type { ProjectCategory } from "@/types/project";
+import type { TransactionPhase } from "@/lib/transaction-progress";
+
+export type TransactionPhaseHandler = (
+  phase: TransactionPhase,
+  meta?: { txHash?: string; error?: Error },
+) => void;
+
+export interface SorobanTransactionOptions {
+  onPhaseChange?: TransactionPhaseHandler;
+  signal?: AbortSignal;
+  timeoutMs?: number;
+  intervalMs?: number;
+}
+
+export interface ProjectData {
+  id: string;
+  name: string;
+  category: ProjectCategory;
+  description: string;
+  websiteUrl: string;
+  githubUrl?: string;
+  logoUrl: string;
+  docsUrl: string;
+  auditReportUrl?: string;
+  bugBountyUrl?: string;
+  owner: string;
+  createdAt: string;
+}
+
+export interface ProjectRegistrationParams {
+  name: string;
+  category: ProjectCategory;
+  description: string;
+  websiteUrl: string;
+  githubUrl?: string;
+  logoUrl?: string;
+  docsUrl?: string;
+  contractAddresses?: string[];
+}
+
+export interface TransactionResult {
+  hash: string;
+  status: "SUCCESS";
+}
+
+export interface VerificationStatusResponse {
+  projectExists: boolean;
+  requestExists: boolean;
+  status: "NONE" | "PENDING" | "VERIFIED" | "REJECTED";
+  rejectionReason?: string;
+}
+
+/**
+ * Public interface for the Soroban service.
+ *
+ * All service consumers should accept `ISorobanService` instead of the
+ * concrete module so that mocks can be injected in tests.
+ */
+export interface ISorobanService {
+  registerProject(
+    params: ProjectRegistrationParams,
+    options?: SorobanTransactionOptions,
+  ): Promise<TransactionResult>;
+
+  updateProject(
+    projectId: string,
+    params: ProjectRegistrationParams,
+    options?: SorobanTransactionOptions,
+  ): Promise<TransactionResult>;
+
+  transferOwnership(
+    projectId: string,
+    newOwnerAddress: string,
+    options?: SorobanTransactionOptions,
+  ): Promise<TransactionResult>;
+
+  requestVerification(
+    projectId: string,
+    projectName: string,
+  ): Promise<TransactionResult>;
+
+  getVerificationStatus(
+    projectId: string,
+    signal?: AbortSignal,
+  ): Promise<"NONE" | "PENDING" | "VERIFIED" | "REJECTED">;
+
+  getVerificationRequestStatus(
+    projectId: string,
+    signal?: AbortSignal,
+  ): Promise<VerificationStatusResponse>;
+
+  getProject(projectId: string): Promise<ProjectData | null>;
+}

--- a/dongle/services/stellar/soroban.mock.ts
+++ b/dongle/services/stellar/soroban.mock.ts
@@ -1,0 +1,114 @@
+/**
+ * Mock Soroban service for unit and integration tests (#422).
+ *
+ * Implements `ISorobanService` with in-memory state so that consumers can
+ * be tested without hitting a real Stellar network or wallet extension.
+ */
+
+import type {
+  ISorobanService,
+  ProjectData,
+  ProjectRegistrationParams,
+  SorobanTransactionOptions,
+  TransactionResult,
+  VerificationStatusResponse,
+} from "./soroban.interface";
+
+export class MockSorobanService implements ISorobanService {
+  private projects = new Map<string, ProjectData>();
+  private verificationStatuses = new Map<
+    string,
+    "NONE" | "PENDING" | "VERIFIED" | "REJECTED"
+  >();
+  private nextId = 1;
+
+  /** Seed a project into the mock store. */
+  seedProject(project: ProjectData): void {
+    this.projects.set(project.id, project);
+  }
+
+  /** Set the verification status for a project. */
+  seedVerification(
+    projectId: string,
+    status: "NONE" | "PENDING" | "VERIFIED" | "REJECTED",
+  ): void {
+    this.verificationStatuses.set(projectId, status);
+  }
+
+  /** Reset all internal state. */
+  reset(): void {
+    this.projects.clear();
+    this.verificationStatuses.clear();
+    this.nextId = 1;
+  }
+
+  async registerProject(
+    params: ProjectRegistrationParams,
+    _options?: SorobanTransactionOptions,
+  ): Promise<TransactionResult> {
+    const id = `mock-project-${this.nextId++}`;
+    const now = new Date().toISOString();
+    this.projects.set(id, {
+      id,
+      name: params.name,
+      category: params.category,
+      description: params.description,
+      websiteUrl: params.websiteUrl,
+      githubUrl: params.githubUrl,
+      logoUrl: params.logoUrl ?? "",
+      docsUrl: params.docsUrl ?? "",
+      owner: "GMOCKADDRESSAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+      createdAt: now,
+    });
+    return { hash: `mock-tx-${id}`, status: "SUCCESS" };
+  }
+
+  async updateProject(
+    projectId: string,
+    params: ProjectRegistrationParams,
+    _options?: SorobanTransactionOptions,
+  ): Promise<TransactionResult> {
+    const existing = this.projects.get(projectId);
+    if (!existing) throw new Error("Project not found");
+    this.projects.set(projectId, { ...existing, ...params });
+    return { hash: `mock-tx-update-${projectId}`, status: "SUCCESS" };
+  }
+
+  async transferOwnership(
+    projectId: string,
+    _newOwnerAddress: string,
+    _options?: SorobanTransactionOptions,
+  ): Promise<TransactionResult> {
+    if (!this.projects.has(projectId)) throw new Error("Project not found");
+    return { hash: `mock-tx-transfer-${projectId}`, status: "SUCCESS" };
+  }
+
+  async requestVerification(
+    projectId: string,
+    _projectName: string,
+  ): Promise<TransactionResult> {
+    this.verificationStatuses.set(projectId, "PENDING");
+    return { hash: `mock-verify-${projectId}`, status: "SUCCESS" };
+  }
+
+  async getVerificationStatus(
+    projectId: string,
+  ): Promise<"NONE" | "PENDING" | "VERIFIED" | "REJECTED"> {
+    return this.verificationStatuses.get(projectId) ?? "NONE";
+  }
+
+  async getVerificationRequestStatus(
+    projectId: string,
+  ): Promise<VerificationStatusResponse> {
+    const status = this.verificationStatuses.get(projectId) ?? "NONE";
+    return {
+      projectExists: this.projects.has(projectId),
+      requestExists: status !== "NONE",
+      status,
+    };
+  }
+
+  async getProject(projectId: string): Promise<ProjectData | null> {
+    return this.projects.get(projectId) ?? null;
+  }
+}

--- a/dongle/services/stellar/soroban.service.ts
+++ b/dongle/services/stellar/soroban.service.ts
@@ -16,56 +16,17 @@ import {
 import { type ProjectCategory, PROJECT_CATEGORIES } from "@/types/project";
 import type { TransactionPhase } from "@/lib/transaction-progress";
 import { validateStellarAddress } from "@/lib/stellar-address";
+import {
+  WalletNotConnectedError,
+  NetworkMismatchError,
+  TransactionFailedError,
+  ContractCallError,
+} from "@/lib/errors";
+import type { ISorobanService } from "./soroban.interface";
 
 const server = new rpc.Server(SOROBAN_CONFIG.RPC_URL, {
   timeout: 15000,
 });
-
-export type TransactionPhaseHandler = (
-  phase: TransactionPhase,
-  meta?: { txHash?: string; error?: Error },
-) => void;
-
-export interface SorobanTransactionOptions {
-  onPhaseChange?: TransactionPhaseHandler;
-  signal?: AbortSignal;
-  timeoutMs?: number;
-  intervalMs?: number;
-}
-
-// ─── Network mismatch error ──────────────────────────────────────────────────
-
-export class NetworkMismatchError extends Error {
-  readonly expectedNetwork: string;
-  readonly actualNetwork: string | null;
-
-  constructor(actual: string | null) {
-    const expectedLabel = EXPECTED_NETWORK_LABEL;
-    const actualLabel = getNetworkLabel(actual);
-    super(
-      `Wrong network: wallet is on ${actualLabel}, but this app requires ${expectedLabel}. ` +
-        `Please switch your Freighter wallet to ${expectedLabel} and try again.`,
-    );
-    this.name = "NetworkMismatchError";
-    this.expectedNetwork = EXPECTED_NETWORK_PASSPHRASE;
-    this.actualNetwork = actual;
-  }
-}
-
-// ─── Wallet not connected error ──────────────────────────────────────────────
-
-/**
- * Thrown when a transaction is attempted without a connected wallet.
- * Always surfaces as a real error — never silently falls back to mock data.
- */
-export class WalletNotConnectedError extends Error {
-  constructor() {
-    super(
-      "No wallet connected. Please connect your Freighter wallet and try again.",
-    );
-    this.name = "WalletNotConnectedError";
-  }
-}
 
 /**
  * Validates that the wallet is on the expected network before any transaction.
@@ -74,7 +35,11 @@ export class WalletNotConnectedError extends Error {
 async function assertCorrectNetwork(): Promise<void> {
   const passphrase = await walletService.getNetworkPassphrase();
   if (passphrase !== EXPECTED_NETWORK_PASSPHRASE) {
-    throw new NetworkMismatchError(passphrase);
+    throw new NetworkMismatchError(
+      passphrase,
+      EXPECTED_NETWORK_PASSPHRASE,
+      EXPECTED_NETWORK_LABEL,
+    );
   }
 }
 
@@ -173,8 +138,9 @@ async function pollTransaction(
   }
 
   if (last.status !== "SUCCESS") {
-    throw new Error(
-      `[SorobanService] Transaction ${hash} failed with status: ${last.status}`,
+    throw new TransactionFailedError(
+      `Transaction ${hash} failed with status: ${last.status}`,
+      hash,
     );
   }
 
@@ -218,8 +184,9 @@ async function executeContractTransaction(
   );
 
   if (sendResponse.status === "ERROR") {
-    throw new Error(
+    throw new TransactionFailedError(
       "Transaction failed: " + JSON.stringify(sendResponse.errorResult),
+      sendResponse.hash,
     );
   }
 
@@ -430,9 +397,9 @@ export const sorobanService = {
     }
 
     const project = await this.getProject(projectId);
-    if (!project) throw new Error("Project not found");
+    if (!project) throw new ContractCallError("Project not found");
     if (project.owner !== publicKey) {
-      throw new Error("Only project owner can update the project");
+      throw new ContractCallError("Only project owner can update the project");
     }
 
     const args = [
@@ -479,15 +446,15 @@ export const sorobanService = {
     }
 
     const project = await this.getProject(projectId);
-    if (!project) throw new Error("Project not found");
+    if (!project) throw new ContractCallError("Project not found");
     if (project.owner !== publicKey) {
-      throw new Error("Only the current project owner can transfer ownership");
+      throw new ContractCallError("Only the current project owner can transfer ownership");
     }
 
     // Validate new owner address
     const validation = validateStellarAddress(newOwnerAddress);
     if (!validation.valid) {
-      throw new Error(validation.error);
+      throw new ContractCallError(validation.error);
     }
 
     const args = [

--- a/dongle/utils/error-mapper.util.ts
+++ b/dongle/utils/error-mapper.util.ts
@@ -3,6 +3,24 @@
  * Converts technical errors into user-friendly messages while preserving developer diagnostics
  */
 
+import {
+  DomainError,
+  WalletError,
+  WalletNotConnectedError,
+  WalletLockedError,
+  WalletNotInstalledError,
+  NetworkError,
+  NetworkTimeoutError,
+  NetworkMismatchError,
+  SorobanError,
+  TransactionFailedError,
+  ContractCallError,
+  AccountError,
+  InsufficientBalanceError,
+  StorageError,
+  DataIntegrityError,
+} from "@/lib/errors";
+
 export interface MappedError {
   userMessage: string;
   technicalDetails?: string;
@@ -21,9 +39,60 @@ export type ErrorCategory =
   | "unknown";
 
 /**
- * Maps technical error messages to user-friendly messages
+ * Maps technical error messages to user-friendly messages.
+ *
+ * If the error is an instance of one of the custom error classes defined in
+ * `@/lib/errors`, the mapping is immediate — no string heuristics needed.
  */
 export function mapError(error: unknown, category?: ErrorCategory): MappedError {
+  // Fast-path: custom error classes carry their own user-friendly payload.
+  if (error instanceof WalletNotConnectedError) {
+    return { userMessage: error.message, code: error.code, actionable: error.actionable, technicalDetails: error.message };
+  }
+  if (error instanceof WalletLockedError) {
+    return { userMessage: error.message, code: error.code, actionable: error.actionable, technicalDetails: error.message };
+  }
+  if (error instanceof WalletNotInstalledError) {
+    return { userMessage: error.message, code: error.code, actionable: error.actionable, technicalDetails: error.message };
+  }
+  if (error instanceof WalletError) {
+    return { userMessage: error.message, code: error.code, actionable: error.actionable, technicalDetails: error.message };
+  }
+  if (error instanceof NetworkTimeoutError) {
+    return { userMessage: error.message, code: error.code, actionable: error.actionable, technicalDetails: error.message };
+  }
+  if (error instanceof NetworkMismatchError) {
+    return { userMessage: error.message, code: error.code, actionable: error.actionable, technicalDetails: error.message };
+  }
+  if (error instanceof NetworkError) {
+    return { userMessage: error.message, code: error.code, actionable: error.actionable, technicalDetails: error.message };
+  }
+  if (error instanceof TransactionFailedError) {
+    return { userMessage: error.message, code: error.code, actionable: error.actionable, technicalDetails: error.message };
+  }
+  if (error instanceof ContractCallError) {
+    return { userMessage: error.message, code: error.code, actionable: error.actionable, technicalDetails: error.message };
+  }
+  if (error instanceof SorobanError) {
+    return { userMessage: error.message, code: error.code, actionable: error.actionable, technicalDetails: error.message };
+  }
+  if (error instanceof InsufficientBalanceError) {
+    return { userMessage: error.message, code: error.code, actionable: error.actionable, technicalDetails: error.message };
+  }
+  if (error instanceof AccountError) {
+    return { userMessage: error.message, code: error.code, actionable: error.actionable, technicalDetails: error.message };
+  }
+  if (error instanceof StorageError) {
+    return { userMessage: error.message, code: error.code, actionable: error.actionable, technicalDetails: error.message };
+  }
+  if (error instanceof DataIntegrityError) {
+    return { userMessage: error.message, code: error.code, actionable: error.actionable, technicalDetails: error.message };
+  }
+  if (error instanceof DomainError) {
+    return { userMessage: error.message, code: error.code, actionable: error.actionable, technicalDetails: error.message };
+  }
+
+  // Legacy path: string-based heuristics for plain Error / unknown values.
   const errorMessage = getErrorMessage(error);
   const errorCode = getErrorCode(error);
 


### PR DESCRIPTION
Fixes #422
Fixes #424
Fixes #450
Fixes #452

## What changed

### #422 — Soroban Service Interface Pattern
- Created `ISorobanService` interface in `services/stellar/soroban.interface.ts` defining all public methods (`registerProject`, `updateProject`, `transferOwnership`, `requestVerification`, `getVerificationStatus`, `getVerificationRequestStatus`, `getProject`).
- Created `MockSorobanService` in `services/stellar/soroban.mock.ts` implementing the interface with in-memory state for testing.
- `soroban.service.ts` now imports the interface type so consumers can depend on `ISorobanService` instead of the concrete class.

### #424 — Consolidate Error Handling
- Added custom error classes in `lib/errors.ts`: `DomainError` (base), `WalletError`, `WalletNotConnectedError`, `WalletLockedError`, `WalletNotInstalledError`, `NetworkError`, `NetworkTimeoutError`, `NetworkMismatchError`, `SorobanError`, `TransactionFailedError`, `ContractCallError`, `AccountError`, `InsufficientBalanceError`, `StorageError`, `DataIntegrityError`.
- Each class carries a `code` string and optional `actionable` hint.
- Updated `error-mapper.util.ts` to handle custom error classes via `instanceof` before falling back to string heuristics.
- Replaced all plain `new Error(...)` throws in `soroban.service.ts` with domain-specific error classes.

### #450 — Project Backup & Migration Tools
- Created `services/project/backup.service.ts` with:
  - `exportProject(id)` — serializes a project with SHA-256 checksum
  - `exportAllProjects(ids)` — batch export
  - `validateImport(backup)` — validates version, required fields, and checksum integrity
  - `generateShareQr(backup)` — encodes backup as a shareable data URL
  - `downloadBackup(backup, filename)` — triggers browser download

### #452 — Audit Trail & Compliance
- Extended `audit-log.service.ts` with:
  - `redactedList(filter?)` — returns entries with wallet addresses partially redacted (first 5 + last 5 chars)
  - `exportCsv(filter?)` — generates CSV string for external audit tools
  - `pruneOldEntries()` — removes entries older than 1 year (retention policy)

## How to test
- **#422**: Import `ISorobanService` in a test file, inject `MockSorobanService`, verify methods work without network calls.
- **#424**: Throw `new WalletNotConnectedError()` and pass to `mapError()` — verify `code` and `actionable` are returned.
- **#450**: Call `exportProject` then `validateImport` on the result — checksum should match.
- **#452**: Append entries, call `exportCsv()` — verify CSV format. Call `redactedList()` — verify addresses are redacted.